### PR TITLE
Added includes and EPROTO to compile on mingw32

### DIFF
--- a/mingw.mutex.h
+++ b/mingw.mutex.h
@@ -18,6 +18,13 @@
 #ifndef WIN32STDMUTEX_H
 #define WIN32STDMUTEX_H
 
+#ifndef EPROTO
+#define EPROTO 134
+#endif
+
+#include <cstdio>
+#include <pthread.h>
+
 #if !defined(STDTHREAD_STRICT_NONRECURSIVE_LOCKS) && !defined(NDEBUG)
     #define STDTHREAD_STRICT_NONRECURSIVE_LOCKS
 #endif


### PR DESCRIPTION
To compile this code on mingw32 cstdio (e.g. for stderr) and pthreads.h (e.g. for EOWNERDEAD) need to be included.
EPROTO is for some reason not defined in the errno.h header in mingw32 so it has to be seperatly defined.