### PR TITLE
Reorder variable declarations to omit -Wreorder

### DIFF
--- a/mingw.condition_variable.h
+++ b/mingw.condition_variable.h
@@ -28,9 +28,9 @@ class condition_variable_any
 {
 protected:
     recursive_mutex mMutex;
+    atomic<int> mNumWaiters;
     HANDLE mSemaphore;
     HANDLE mWakeEvent;
-    atomic<int> mNumWaiters;
 public:
     typedef HANDLE native_handle_type;
     native_handle_type native_handle() {return mSemaphore;}


### PR DESCRIPTION
If you try to compile code with -Wall -Werror the code won't compile.