### PR TITLE
Mark global functions as inline.

### DIFF
--- a/mingw.thread.h
+++ b/mingw.thread.h
@@ -106,8 +106,8 @@ public:
 };
 namespace this_thread
 {
-    thread::id get_id() {return thread::id(GetCurrentThreadId());}
-    void yield() {Sleep(0);}
+    inline thread::id get_id() {return thread::id(GetCurrentThreadId());}
+    inline void yield() {Sleep(0);}
     template< class Rep, class Period >
     void sleep_for( const std::chrono::duration<Rep,Period>& sleep_duration)
     {


### PR DESCRIPTION
Both `this_thread::get_id()` and `this_thread::yield()` need to be marked as
inline, to avoid linker errors about multiple definitions.