### PR TITLE
Various interface/include fixes

### DIFF
--- a/mingw.condition_variable.h
+++ b/mingw.condition_variable.h
@@ -11,6 +11,9 @@
 #include <atomic>
 #include <assert.h>
 #include <condition_variable>
+#include <chrono>
+#include <system_error>
+
 namespace std
 {
 

--- a/mingw.mutex.h
+++ b/mingw.mutex.h
@@ -13,6 +13,9 @@
     #define STDTHREAD_STRICT_NONRECURSIVE_LOCKS
 #endif
 
+#include <chrono>
+#include <system_error>
+
 namespace std
 {
 class recursive_mutex
@@ -205,7 +208,7 @@ public:
     }
 };
 // You can use the scoped locks and other helpers that are still provided by <mutex>
-// In that case, you must include <mutex> before inclusing this file, so that this
+// In that case, you must include <mutex> before including this file, so that this
 // file will not try to redefine them
 #ifndef _GLIBCXX_MUTEX
 

--- a/mingw.thread.h
+++ b/mingw.thread.h
@@ -41,12 +41,16 @@ public:
     id get_id() const noexcept {return mThreadId;}
     native_handle_type native_handle() const {return mHandle;}
     thread(): mHandle(_STD_THREAD_INVALID_HANDLE){}
-    thread(thread& other)
+
+    thread(thread&& other)
     :mHandle(other.mHandle), mThreadId(other.mThreadId)
     {
         other.mHandle = _STD_THREAD_INVALID_HANDLE;
         other.mThreadId.clear();
     }
+
+    thread(const thread &other)=delete;
+
     template<class Function, class... Args>
     explicit thread(Function&& f, Args&&... args)
     {


### PR DESCRIPTION
I fixed a few interface/compatibility bugs here and there; the most prominent one is the incorrect "non-`const` copy constructor" of your `std::thread` implementation, which should be a move constructor (this triggered some errors in my codebase).

Also, in headers other than `mingw.thread.h` there are some missing includes, which probably went unnoticed because other versions of the mingw toolchain already include them in some other common header.