### PR TITLE
add std qualifications & check result of _beginthreadex & cleanups

### DIFF
--- a/mingw.condition_variable.h
+++ b/mingw.condition_variable.h
@@ -90,7 +90,7 @@ protected:
 //The notify_all() must handle this grafecully
 //
         else
-            throw system_error(EPROTO, generic_category());
+            throw std::system_error(EPROTO, std::generic_category());
     }
 public:
     template <class M>
@@ -118,7 +118,7 @@ public:
         {
             auto ret = WaitForSingleObject(mWakeEvent, 1000);
             if ((ret == WAIT_FAILED) || (ret == WAIT_ABANDONED))
-                throw system_error(EPROTO, generic_category());
+                throw std::system_error(EPROTO, std::generic_category());
         }
         assert(mNumWaiters == 0);
 //in case some of the waiters timed out just after we released the
@@ -139,7 +139,7 @@ public:
         {
             auto ret = WaitForSingleObject(mWakeEvent, 1000);
             if ((ret == WAIT_FAILED) || (ret == WAIT_ABANDONED))
-                throw system_error(EPROTO, generic_category());
+                throw std::system_error(EPROTO, std::generic_category());
         }
         assert(mNumWaiters == targetWaiters);
     }

--- a/mingw.mutex.h
+++ b/mingw.mutex.h
@@ -106,9 +106,9 @@ protected:
         DWORD self = GetCurrentThreadId();
         if (mOwnerThread == self)
         {
-            fprintf(stderr, "FATAL: Recursive locking or non-recursive mutex detected. Throwing sysetm exception\n");
-            fflush(stderr);
-            throw system_error(EDEADLK, generic_category());
+            std::fprintf(stderr, "FATAL: Recursive locking or non-recursive mutex detected. Throwing sysetm exception\n");
+            std::fflush(stderr);
+            throw std::system_error(EDEADLK, std::generic_category());
         }
         mOwnerThread = self;
     }
@@ -117,9 +117,9 @@ protected:
         DWORD self = GetCurrentThreadId();
         if (mOwnerThread != self)
         {
-            fprintf(stderr, "FATAL: Recursive unlocking of non-recursive mutex detected. Throwing system exception\n");
-            fflush(stderr);
-            throw system_error(EDEADLK, generic_category());
+            std::fprintf(stderr, "FATAL: Recursive unlocking of non-recursive mutex detected. Throwing system exception\n");
+            std::fflush(stderr);
+            throw std::system_error(EDEADLK, std::generic_category());
         }
         mOwnerThread = 0;
     }
@@ -164,15 +164,15 @@ public:
         if (ret != WAIT_OBJECT_0)
         {
             if (ret == WAIT_ABANDONED)
-                throw system_error(EOWNERDEAD, generic_category());
+                throw std::system_error(EOWNERDEAD, std::generic_category());
             else
-                throw system_error(EPROTO, generic_category());
+                throw std::system_error(EPROTO, std::generic_category());
         }
     }
     void unlock()
     {
         if (!ReleaseMutex(mHandle))
-            throw system_error(EDEADLK, generic_category());
+            throw std::system_error(EDEADLK, std::generic_category());
     }
     bool try_lock()
     {
@@ -182,9 +182,9 @@ public:
         else if (ret == WAIT_OBJECT_0)
             return true;
         else if (ret == WAIT_ABANDONED)
-            throw system_error(EOWNERDEAD, generic_category());
+            throw std::system_error(EOWNERDEAD, std::generic_category());
         else
-            throw system_error(EPROTO, generic_category());
+            throw std::system_error(EPROTO, std::generic_category());
     }
     template <class Rep, class Period>
     bool try_lock_for(const std::chrono::duration<Rep,Period>& dur)
@@ -197,9 +197,9 @@ public:
         else if (ret == WAIT_OBJECT_0)
             return true;
         else if (ret == WAIT_ABANDONED)
-            throw system_error(EOWNERDEAD, generic_category());
+            throw std::system_error(EOWNERDEAD, std::generic_category());
         else
-            throw system_error(EPROTO, generic_category());
+            throw std::system_error(EPROTO, std::generic_category());
     }
     template <class Clock, class Duration>
     bool try_lock_until(const std::chrono::time_point<Clock,Duration>& timeout_time)

--- a/mingw.mutex.h
+++ b/mingw.mutex.h
@@ -42,6 +42,7 @@
 #include <windows.h>
 #include <chrono>
 #include <system_error>
+#include <cstdio>
 
 #ifndef EPROTO
     #define EPROTO 134

--- a/mingw.thread.h
+++ b/mingw.thread.h
@@ -55,7 +55,7 @@ public:
         void clear() {mId = 0;}
         friend class thread;
     public:
-        id(DWORD aId=0):mId(aId){}
+        explicit id(DWORD aId=0):mId(aId){}
         bool operator==(const id& other) const {return mId == other.mId;}
     };
 protected:
@@ -100,7 +100,7 @@ public:
     bool joinable() const {return mHandle != _STD_THREAD_INVALID_HANDLE;}
     void join()
     {
-        if (get_id() == GetCurrentThreadId())
+        if (get_id() == id(GetCurrentThreadId()))
             throw std::system_error(EDEADLK, std::generic_category());
         if (mHandle == _STD_THREAD_INVALID_HANDLE)
             throw std::system_error(ESRCH, std::generic_category());

--- a/mingw.thread.h
+++ b/mingw.thread.h
@@ -94,11 +94,11 @@ public:
     void join()
     {
         if (get_id() == GetCurrentThreadId())
-            throw system_error(EDEADLK, generic_category());
+            throw std::system_error(EDEADLK, std::generic_category());
         if (mHandle == _STD_THREAD_INVALID_HANDLE)
-            throw system_error(ESRCH, generic_category());
+            throw std::system_error(ESRCH, std::generic_category());
         if (!joinable())
-            throw system_error(EINVAL, generic_category());
+            throw std::system_error(EINVAL, std::generic_category());
         WaitForSingleObject(mHandle, INFINITE);
         CloseHandle(mHandle);
         mHandle = _STD_THREAD_INVALID_HANDLE;
@@ -137,7 +137,7 @@ public:
     void detach()
     {
         if (!joinable())
-            throw system_error();
+            throw std::system_error(EINVAL, std::generic_category());
         if (mHandle != _STD_THREAD_INVALID_HANDLE)
         {
             CloseHandle(mHandle);
@@ -154,7 +154,7 @@ namespace this_thread
     template< class Rep, class Period >
     void sleep_for( const std::chrono::duration<Rep,Period>& sleep_duration)
     {
-        Sleep(chrono::duration_cast<chrono::milliseconds>(sleep_duration).count());
+        Sleep(std::chrono::duration_cast<std::chrono::milliseconds>(sleep_duration).count());
     }
     template <class Clock, class Duration>
     void sleep_until(const std::chrono::time_point<Clock,Duration>& sleep_time)

--- a/mingw.thread.h
+++ b/mingw.thread.h
@@ -25,6 +25,7 @@
 #include <memory>
 #include <chrono>
 #include <system_error>
+#include <cerrno>
 #include <process.h>
 
 #ifdef _GLIBCXX_HAS_GTHREADS
@@ -82,6 +83,12 @@ public:
         Call* call = new Call(std::bind(f, args...));
         mHandle = (HANDLE)_beginthreadex(NULL, 0, threadfunc<Call>,
             (LPVOID)call, 0, (unsigned*)&(mThreadId.mId));
+        if (mHandle == _STD_THREAD_INVALID_HANDLE)
+        {
+            int errnum = errno;
+            delete call;
+            throw std::system_error(errnum, std::generic_category());
+        }
     }
     template <class Call>
     static unsigned int __stdcall threadfunc(void* arg)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 project(stdthreadtest)
 cmake_minimum_required(VERSION 2.8)
 
-add_definitions(-std=c++11)
+add_definitions(-std=c++11 -Wall -Wextra)
 add_executable(${PROJECT_NAME} tests.cpp)
 
 


### PR DESCRIPTION
hello,

First commit "qualify exceptions and chrono with std": 
I found mingw.thread.h also useful when building in static with MSVC, because MSVC's std::thread pull >100 kB of Concurrency Runtime even when only used to create a new thread... (ironically the Concurrency Runtime is not used anymore in MSVC2015 to *create* threads, however in its std::thread class implementation a condition variable is used - for no real reason it seems - and both mutex and condition variable still use the Concurrency Runtime...)

My approach is to just take the mingw.thread.h file and change the namespace, and do a e.g. "using win32_std::thread" in the application code. Therefore, this patch qualify uses of system_error, generic_category, and chrono with std:: so that they resist the potential englobing namespace change.

I also added params in the system_error() call in detach(), to be compatible with MSVC.

Cheers!