### PR TITLE
Fix possible race condition in condition_variable

### DIFF
--- a/mingw.condition_variable.h
+++ b/mingw.condition_variable.h
@@ -131,9 +131,9 @@ public:
     void notify_one() noexcept
     {
         lock_guard<recursive_mutex> lock(mMutex);
-        if (!mNumWaiters)
-            return;
         int targetWaiters = mNumWaiters.load() - 1;
+        if (targetWaiters <= -1)
+            return;
         ReleaseSemaphore(mSemaphore, 1, NULL);
         while(mNumWaiters > targetWaiters)
         {


### PR DESCRIPTION
This PR fixes a race condition between condition_variable::notify_one and wait_impl.
To trigger the race condition the following events need to occur:

1. Suppose we have a condition_variable cv and at least 2 threads.
2. Thread A enters wait_impl and stops at WaitForSingleObject with a finite timeout, mNumWaiters==1 at this point
3. Thread B enters notify_one, checks !mNumWaiters and the scheduler stops it before executing mNumWaiters.load()
4. WaitForSingleObject times out at Thread A and wait_impl returns. mNumWaiters==0
5. Thread B continues and sets targetWaiters to -1, causing an infinite loop while waiting for mNumWaiters to become -1

The fix is simple, only read mNumWaiters once during setup, so timeouts won't cause problems.