### PR TITLE
Better standard compliance, mingw.shared_mutex.h, and selection of native implementations if compiling for high enough Windows versions.

### DIFF
--- a/mingw.condition_variable.h
+++ b/mingw.condition_variable.h
@@ -24,7 +24,9 @@
 #include <atomic>
 #include <assert.h>
 #include "mingw.mutex.h"
+#if WINVER >= 0x0601
 #include "mingw.shared_mutex.h"
+#endif
 #include <chrono>
 #include <system_error>
 #include <windows.h>
@@ -346,8 +348,8 @@ protected:
   {
     return base::wait_impl(lock, time);
   }
-
-  typedef std::win32::vista::shared_mutex native_shared_mutex;
+#if WINVER >= 0x0601
+  typedef std::win32::windows7::shared_mutex native_shared_mutex;
   bool wait_impl (std::unique_lock<native_shared_mutex> & lock, DWORD time)
   {
     static_assert(CONDITION_VARIABLE_LOCKMODE_SHARED != 0,
@@ -369,6 +371,7 @@ protected:
     lock = std::shared_lock<native_shared_mutex>(*pmutex, std::adopt_lock);
     return success;
   }
+#endif
 public:
   typedef typename base::native_handle_type native_handle_type;
   using base::native_handle;

--- a/mingw.mutex.h
+++ b/mingw.mutex.h
@@ -19,18 +19,6 @@
 
 #ifndef WIN32STDMUTEX_H
 #define WIN32STDMUTEX_H
-#ifdef _GLIBCXX_HAS_GTHREADS
-#error This version of MinGW seems to include a win32 port of pthreads, and probably    \
-    already has C++11 std threading classes implemented, based on pthreads.             \
-    You are likely to have class redefinition errors below, and unfirtunately this      \
-    implementation can not be used standalone                                           \
-    and independent of the system <mutex> header, since it relies on it for             \
-    std::unique_lock and other utility classes. If you would still like to use this     \
-    implementation (as it is more lightweight), you have to edit the                    \
-    c++-config.h system header of your MinGW to not define _GLIBCXX_HAS_GTHREADS.       \
-    This will prevent system headers from defining actual threading classes while still \
-    defining the necessary utility classes.
-#endif
 // Recursion checks on non-recursive locks have some performance penalty, so the user
 // may want to disable the checks in release builds. In that case, make sure they
 // are always enabled in debug builds.
@@ -43,6 +31,7 @@
 #include <chrono>
 #include <system_error>
 #include <cstdio>
+#include <mutex>
 
 #ifndef EPROTO
     #define EPROTO 134
@@ -255,14 +244,20 @@ public:
     }
 };
 } //  Namespace xp
+using xp::mutex;
+using xp::timed_mutex;
+using xp::recursive_mutex;
+using xp::recursive_timed_mutex;
+#if defined(__MINGW32__) && !defined(_GLIBCXX_HAS_GTHREADS)
 } //  Namespace mingw_stdthread
 
 namespace std
 {
-using ::mingw_stdthread::xp::mutex;
-using ::mingw_stdthread::xp::timed_mutex;
-using ::mingw_stdthread::xp::recursive_mutex;
-using ::mingw_stdthread::xp::recursive_timed_mutex;
+using ::mingw_stdthread::mutex;
+using ::mingw_stdthread::timed_mutex;
+using ::mingw_stdthread::recursive_mutex;
+using ::mingw_stdthread::recursive_timed_mutex;
+#endif
 // You can use the scoped locks and other helpers that are still provided by <mutex>
 // In that case, you must include <mutex> before including this file, so that this
 // file will not try to redefine them

--- a/mingw.mutex.h
+++ b/mingw.mutex.h
@@ -84,6 +84,15 @@ public:
         return (TryEnterCriticalSection(&mHandle)!=0);
     }
 };
+#ifndef STDMUTEX_NO_RECURSION_CHECKS
+namespace win32
+{
+namespace vista
+{
+class condition_variable;
+}
+}
+#endif
 
 template <class B>
 class _NonRecursive: protected B

--- a/mingw.mutex.h
+++ b/mingw.mutex.h
@@ -53,14 +53,15 @@
 
 namespace mingw_stdthread
 {
-namespace win32
-{
 #ifndef STDMUTEX_NO_RECURSION_CHECKS
 namespace vista
 {
 class condition_variable;
 }
 #endif
+
+namespace xp
+{
 
 class recursive_mutex
 {
@@ -100,7 +101,7 @@ class _NonRecursive: protected B
 protected:
 #ifndef STDMUTEX_NO_RECURSION_CHECKS
 //    Allow condition variable to unlock the native handle directly.
-    friend class ::mingw_stdthread::win32::vista::condition_variable;
+    friend class vista::condition_variable;
 #endif
     typedef B base;
     DWORD mOwnerThread;
@@ -253,15 +254,15 @@ public:
         return ret;
     }
 };
-} //  Namespace win32
+} //  Namespace xp
 } //  Namespace mingw_stdthread
 
 namespace std
 {
-using ::mingw_stdthread::win32::mutex;
-using ::mingw_stdthread::win32::timed_mutex;
-using ::mingw_stdthread::win32::recursive_mutex;
-using ::mingw_stdthread::win32::recursive_timed_mutex;
+using ::mingw_stdthread::xp::mutex;
+using ::mingw_stdthread::xp::timed_mutex;
+using ::mingw_stdthread::xp::recursive_mutex;
+using ::mingw_stdthread::xp::recursive_timed_mutex;
 // You can use the scoped locks and other helpers that are still provided by <mutex>
 // In that case, you must include <mutex> before including this file, so that this
 // file will not try to redefine them

--- a/mingw.mutex.h
+++ b/mingw.mutex.h
@@ -51,8 +51,17 @@
     #define EOWNERDEAD 133
 #endif
 
-namespace std
+namespace mingw_stdthread
 {
+namespace win32
+{
+#ifndef STDMUTEX_NO_RECURSION_CHECKS
+namespace vista
+{
+class condition_variable;
+}
+#endif
+
 class recursive_mutex
 {
 protected:
@@ -84,15 +93,6 @@ public:
         return (TryEnterCriticalSection(&mHandle)!=0);
     }
 };
-#ifndef STDMUTEX_NO_RECURSION_CHECKS
-namespace win32
-{
-namespace vista
-{
-class condition_variable;
-}
-}
-#endif
 
 template <class B>
 class _NonRecursive: protected B
@@ -100,7 +100,7 @@ class _NonRecursive: protected B
 protected:
 #ifndef STDMUTEX_NO_RECURSION_CHECKS
 //    Allow condition variable to unlock the native handle directly.
-    friend class win32::vista::condition_variable;
+    friend class ::mingw_stdthread::win32::vista::condition_variable;
 #endif
     typedef B base;
     DWORD mOwnerThread;
@@ -253,6 +253,15 @@ public:
         return ret;
     }
 };
+} //  Namespace win32
+} //  Namespace mingw_stdthread
+
+namespace std
+{
+using ::mingw_stdthread::win32::mutex;
+using ::mingw_stdthread::win32::timed_mutex;
+using ::mingw_stdthread::win32::recursive_mutex;
+using ::mingw_stdthread::win32::recursive_timed_mutex;
 // You can use the scoped locks and other helpers that are still provided by <mutex>
 // In that case, you must include <mutex> before including this file, so that this
 // file will not try to redefine them

--- a/mingw.shared_mutex.h
+++ b/mingw.shared_mutex.h
@@ -1,0 +1,428 @@
+/// \file mingw.shared_mutex.h
+/// \brief Standard-compliant shared mutex for MinGW
+///
+/// (c) 2017 by Nathaniel McClatchey, Athens OH, United States
+/// \author Nathaniel J. McClatchey
+///
+/// \copyright Simplified (2-clause) BSD License.
+///
+/// \note This file may become part of the mingw-w64 runtime package. If/when this happens,
+/// the appropriate license will be added, i.e. this code will become dual-licensed,
+/// and the current BSD 2-clause license will stay.
+
+#ifndef MINGW_SHARED_MUTEX_H_
+#define MINGW_SHARED_MUTEX_H_
+
+#if !defined(__cplusplus) || (__cplusplus < 201103L)
+#error A C++11 compiler is required!
+#endif
+
+//    Even if MinGW has supplied the appropriate C++17 shared_mutex
+//  implementation, users may wish to use the native Windows shared mutex, or to
+//  use the lightweight atomics-based shared mutex.
+#if (__cplusplus >= 201703L) && (!defined(__MINGW32__) || defined(_GLIBCXX_HAS_GTHREADS))
+#include <shared_mutex>
+#endif
+
+#include <system_error>
+
+//    Implementing a shared_mutex without OS support will require atomic read-
+//  modify-write capacity.
+#include <atomic>
+//  For this_thread::yield
+#if defined(__MINGW32__) && !defined(_GLIBCXX_HAS_GTHREADS)
+#pragma message "Using native WIN32 threads for shared_mutex (" __FILE__ ")."
+#include "mingw.thread.h"
+#else
+#include <thread>
+#endif
+//  For defer_lock_t, adopt_lock_t, and try_to_lock_t
+#include <mutex>
+//  For timing (in shared_lock and shared_timed_mutex)
+#include <chrono>
+
+//  Might be able to use native Slim Reader-Writer (SRW) locks.
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+
+#include <assert.h>
+
+namespace std
+{
+//  Define a portable atomics-based shared mutex
+namespace portable
+{
+class shared_mutex
+{
+  typedef uint_fast16_t atomic_type;
+  std::atomic<atomic_type> atomic_;
+  static constexpr atomic_type kWriteBit = 1 << (sizeof(atomic_type) * CHAR_BIT - 1);
+ public:
+  typedef shared_mutex * native_handle_type;
+
+  shared_mutex ()
+    : atomic_(0)
+  {
+  }
+
+//  No form of copying or moving should be allowed.
+  shared_mutex (const shared_mutex&) = delete;
+  shared_mutex & operator= (const shared_mutex&) = delete;
+
+  ~shared_mutex ()
+  {
+    assert(atomic_.load(std::memory_order_relaxed) == 0);
+  }
+
+  void lock_shared (void)
+  {
+    atomic_type expected = atomic_.load(std::memory_order_relaxed);
+//  If writing, add a delay. Otherwise, spin until the cmpxchg goes through.
+    do {
+      //if ((expected & kWriteBit) || ((expected + 1) == kWriteBit))
+      if (expected >= kWriteBit - 1)
+      {
+        using namespace std::this_thread;
+        yield();
+        expected = atomic_.load(std::memory_order_relaxed);
+        continue;
+      }
+      //expected &= ~kWriteBit;
+      if (atomic_.compare_exchange_weak(expected, expected + 1,
+                                        std::memory_order_acquire,
+                                        std::memory_order_relaxed))
+        break;
+    } while (true);
+  }
+
+  bool try_lock_shared (void)
+  {
+    atomic_type expected = atomic_.load(std::memory_order_relaxed) & (~kWriteBit);
+    if (expected + 1 == kWriteBit)
+      return false;
+    else
+      return atomic_.compare_exchange_strong( expected, expected + 1,
+                                              std::memory_order_acquire,
+                                              std::memory_order_relaxed);
+  }
+
+  void unlock_shared (void)
+  {
+    using namespace std;
+#ifndef NDEBUG
+    if (!(atomic_.fetch_sub(1, memory_order_release) & (~kWriteBit)))
+      throw system_error(make_error_code(errc::operation_not_permitted));
+#else
+    atomic_.fetch_sub(1, memory_order_release);
+#endif
+  }
+
+//  Behavior is undefined if a lock was previously acquired.
+  void lock (void)
+  {
+    using namespace std::this_thread;
+//  Might be able to use relaxed memory order...
+//  Wait for the write-lock to be unlocked.
+    while (atomic_.fetch_or(kWriteBit, std::memory_order_relaxed) & kWriteBit)
+      yield();
+//  Wait for readers to finish up.
+    while (atomic_.load(std::memory_order_acquire) & (~kWriteBit))
+      yield();
+  }
+
+  bool try_lock (void)
+  {
+    atomic_type expected = 0;
+    return atomic_.compare_exchange_strong(expected, kWriteBit,
+                                         std::memory_order_acquire,
+                                         std::memory_order_relaxed);
+  }
+
+  void unlock (void)
+  {
+    using namespace std;
+#ifndef NDEBUG
+    if (atomic_.load(memory_order_relaxed) != kWriteBit)
+      throw system_error(make_error_code(errc::operation_not_permitted));
+#endif
+    atomic_.store(0, memory_order_release);
+  }
+
+  native_handle_type native_handle (void)
+  {
+    return this;
+  }
+};
+
+} //  Namespace portable
+
+#ifdef _WIN32
+namespace win32
+{
+#if (WINVER >= _WIN32_WINNT_VISTA)
+namespace vista
+{
+class shared_mutex
+{
+  SRWLOCK handle_;
+ public:
+  typedef PSRWLOCK native_handle_type;
+
+  shared_mutex ()
+    : handle_()
+  {
+    InitializeSRWLock(&handle_);
+  }
+
+  ~shared_mutex () = default;
+
+//  No form of copying or moving should be allowed.
+  shared_mutex (const shared_mutex&) = delete;
+  shared_mutex & operator= (const shared_mutex&) = delete;
+
+  void lock_shared (void)
+  {
+    AcquireSRWLockShared(&handle_);
+  }
+
+  bool try_lock_shared (void)
+  {
+    return TryAcquireSRWLockShared(&handle_) != 0;
+  }
+
+  void unlock_shared (void)
+  {
+    ReleaseSRWLockShared(&handle_);
+  }
+
+//  Behavior is undefined if a lock was previously acquired.
+  void lock (void)
+  {
+    AcquireSRWLockExclusive(&handle_);
+  }
+
+  bool try_lock (void)
+  {
+    return TryAcquireSRWLockExclusive(&handle_) != 0;
+  }
+
+  void unlock (void)
+  {
+    ReleaseSRWLockExclusive(&handle_);
+  }
+
+  native_handle_type native_handle (void)
+  {
+    return &handle_;
+  }
+};
+
+} //  Namespace vista
+#endif
+} //  Namespace win32
+#endif  //  Compiling for Win32
+
+//    Though adding anything to the std namespace is generally frowned upon, the
+//  added features are only those intended for inclusion in C++17
+#if (__cplusplus < 201703L) || (defined(__MINGW32__) && !defined(_GLIBCXX_HAS_GTHREADS))
+#if (defined(_WIN32) && (WINVER >= _WIN32_WINNT_VISTA))
+  using win32::vista::shared_mutex;
+#else
+  using portable::shared_mutex;
+#endif
+#endif
+
+//    If not supplied by shared_mutex (eg. because C++17 is not supported), I
+//  supply the various helper classes that the header should have defined.
+#if (__cplusplus < 201402L) || (defined(__MINGW32__) && !defined(_GLIBCXX_HAS_GTHREADS))
+class shared_timed_mutex : protected shared_mutex
+{
+  typedef shared_mutex Base;
+ public:
+  using Base::lock;
+  using Base::try_lock;
+  using Base::unlock;
+  using Base::lock_shared;
+  using Base::try_lock_shared;
+  using Base::unlock_shared;
+
+  template< class Clock, class Duration >
+  bool try_lock_until ( const std::chrono::time_point<Clock,Duration>& cutoff )
+  {
+    do {
+      if (try_lock())
+        return true;
+    } while (std::chrono::steady_clock::now() < cutoff);
+    return false;
+  }
+
+  template< class Rep, class Period >
+  bool try_lock_for (const std::chrono::duration<Rep,Period>& rel_time)
+  {
+    return try_lock_until(std::chrono::steady_clock::now() + rel_time);
+  }
+
+  template< class Clock, class Duration >
+  bool try_lock_shared_until ( const std::chrono::time_point<Clock,Duration>& cutoff )
+  {
+    do {
+      if (try_lock_shared())
+        return true;
+    } while (std::chrono::steady_clock::now() < cutoff);
+    return false;
+  }
+
+  template< class Rep, class Period >
+  bool try_lock_shared_for (const std::chrono::duration<Rep,Period>& rel_time)
+  {
+    return try_lock_shared_until(std::chrono::steady_clock::now() + rel_time);
+  }
+};
+
+template<class Mutex>
+class shared_lock
+{
+  Mutex * mutex_;
+  bool owns_;
+ public:
+  typedef Mutex mutex_type;
+
+  shared_lock (void) noexcept
+    : mutex_(nullptr), owns_(false)
+  {
+  }
+
+  shared_lock (shared_lock<Mutex> && other) noexcept
+    : mutex_(other.mutex_), owns_(other.owns_)
+  {
+    other.mutex_ = nullptr;
+    other.owns_ = false;
+  }
+
+  explicit shared_lock (mutex_type & m)
+    : mutex_(&m), owns_(true)
+  {
+    mutex_->lock_shared();
+  }
+
+  shared_lock (mutex_type & m, defer_lock_t) noexcept
+    : mutex_(&m), owns_(false)
+  {
+  }
+
+  shared_lock (mutex_type & m, adopt_lock_t)
+    : mutex_(&m), owns_(true)
+  {
+  }
+
+  shared_lock (mutex_type & m, try_to_lock_t)
+    : mutex_(&m), owns_(m.try_lock_shared())
+  {
+  }
+
+  template< class Rep, class Period >
+  shared_lock( mutex_type& m, const chrono::duration<Rep,Period>& timeout_duration )
+    : mutex_(&m), owns_(m.try_lock_shared_for(timeout_duration))
+  {
+  }
+
+  template< class Clock, class Duration >
+  shared_lock( mutex_type& m, const chrono::time_point<Clock,Duration>& timeout_time )
+    : mutex_(&m), owns_(m.try_lock_shared_until(timeout_time))
+  {
+  }
+
+
+  ~shared_lock (void)
+  {
+    if (owns_)
+      mutex_->unlock_shared();
+  }
+
+//  Shared locking
+  void lock (void)
+  {
+    if (mutex_ == nullptr)
+      throw system_error(make_error_code(errc::operation_not_permitted));
+    if (owns_)
+      throw system_error(make_error_code(errc::resource_deadlock_would_occur));
+    mutex_->lock_shared();
+  }
+
+  bool try_lock (void)
+  {
+    if (mutex_ == nullptr)
+      throw system_error(make_error_code(errc::operation_not_permitted));
+    if (owns_)
+      throw system_error(make_error_code(errc::resource_deadlock_would_occur));
+    return mutex_->try_lock_shared();
+  }
+
+  template< class Clock, class Duration >
+  bool try_lock_until( const chrono::time_point<Clock,Duration>& cutoff )
+  {
+    if (mutex_ == nullptr)
+      throw system_error(make_error_code(errc::operation_not_permitted));
+    if (owns_)
+      throw system_error(make_error_code(errc::resource_deadlock_would_occur));
+    do {
+      if (mutex_->try_lock_shared())
+        return true;
+    } while (chrono::steady_clock::now() < cutoff);
+    return false;
+  }
+
+  template< class Rep, class Period >
+  bool try_lock_for (const chrono::duration<Rep,Period>& rel_time)
+  {
+    return try_lock_until(chrono::steady_clock::now() + rel_time);
+  }
+
+  void unlock (void)
+  {
+    if (!owns_)
+      throw system_error(make_error_code(errc::operation_not_permitted));
+    mutex_->unlock_shared();
+  }
+
+//  Modifiers
+  void swap (shared_lock<Mutex> & other) noexcept
+  {
+    std::swap(mutex_, other.mutex_);
+    std::swap(owns_, other.owns_);
+  }
+
+  mutex_type * release (void) noexcept
+  {
+    mutex_type * ptr = mutex_;
+    mutex_ = nullptr;
+    owns_ = false;
+    return ptr;
+  }
+//  Observers
+  mutex_type * mutex (void) const noexcept
+  {
+    return mutex_;
+  }
+
+  bool owns_lock (void) const noexcept
+  {
+    return owns_;
+  }
+
+  explicit operator bool () const noexcept
+  {
+    return owns_lock();
+  }
+};
+
+template< class Mutex >
+void swap( shared_lock<Mutex>& lhs, shared_lock<Mutex>& rhs ) noexcept
+{
+  lhs.swap(rhs);
+}
+#endif
+} //  Namespace std
+#endif // MINGW_SHARED_MUTEX_H_

--- a/mingw.shared_mutex.h
+++ b/mingw.shared_mutex.h
@@ -334,12 +334,29 @@ class shared_lock
   {
   }
 
+  shared_lock& operator= (shared_lock<Mutex> && other) noexcept
+  {
+    if (&other != this)
+    {
+      if (owns_)
+        mutex_->unlock_shared();
+      mutex_ = other.mutex_;
+      owns_ = other.owns_;
+      other.mutex_ = nullptr;
+      other.owns_ = false;
+    }
+    return *this;
+  }
+
 
   ~shared_lock (void)
   {
     if (owns_)
       mutex_->unlock_shared();
   }
+
+  shared_lock (const shared_lock<Mutex> &) = delete;
+  shared_lock& operator= (const shared_lock<Mutex> &) = delete;
 
 //  Shared locking
   void lock (void)

--- a/mingw.shared_mutex.h
+++ b/mingw.shared_mutex.h
@@ -158,15 +158,12 @@ class shared_mutex
 
 } //  Namespace portable
 
-#ifdef _WIN32
-namespace win32
-{
 //    The native shared_mutex implementation primarily uses features of Windows
 //  Vista, but the features used for try_lock and try_lock_shared were not
 //  introduced until Windows 7. To allow limited use while compiling for Vista,
 //  I define the class without try_* functions in that case.
 //    Only fully-featured implementations will be placed into namespace std.
-#if (WINVER >= _WIN32_WINNT_VISTA)
+#if defined(_WIN32) && (WINVER >= _WIN32_WINNT_VISTA)
 namespace windows7
 {
 class shared_mutex
@@ -208,7 +205,7 @@ class shared_mutex
     ReleaseSRWLockExclusive(&handle_);
   }
 
-
+//  TryAcquireSRW functions are a Windows 7 feature.
 #if (WINVER >= _WIN32_WINNT_WIN7)
   bool try_lock_shared (void)
   {
@@ -229,8 +226,6 @@ class shared_mutex
 
 } //  Namespace windows7
 #endif  //  Compiling for Vista
-} //  Namespace win32
-#endif  //  Compiling for Win32
 } //  Namespace mingw_stdthread
 
 namespace std
@@ -239,7 +234,7 @@ namespace std
 //  added features are only those intended for inclusion in C++17
 #if (__cplusplus < 201703L) || (defined(__MINGW32__) && !defined(_GLIBCXX_HAS_GTHREADS))
 #if (defined(_WIN32) && (WINVER >= _WIN32_WINNT_WIN7))
-  using ::mingw_stdthread::win32::windows7::shared_mutex;
+  using ::mingw_stdthread::windows7::shared_mutex;
 #else
   using ::mingw_stdthread::portable::shared_mutex;
 #endif

--- a/mingw.thread.h
+++ b/mingw.thread.h
@@ -30,17 +30,8 @@
 #include <utility>
 #include <ostream>
 
-#ifdef _GLIBCXX_HAS_GTHREADS
-#error This version of MinGW seems to include a win32 port of pthreads, and probably    \
-    already has C++11 std threading classes implemented, based on pthreads.             \
-    It is likely that you will get class redefinition errors below, and unfortunately   \
-    this implementation can not be used standalone                                      \
-    and independent of the system <mutex> header, since it relies on it for             \
-    std::unique_lock and other utility classes. If you would still like to use this     \
-    implementation (as it is more lightweight), you have to edit the                    \
-    c++-config.h system header of your MinGW to not define _GLIBCXX_HAS_GTHREADS.       \
-    This will prevent system headers from defining actual threading classes while still \
-    defining the necessary utility classes.
+#if !defined(__MINGW32__) || defined(_GLIBCXX_HAS_GTHREADS)
+#include <thread>
 #endif
 
 //instead of INVALID_HANDLE_VALUE _beginthreadex returns 0
@@ -165,15 +156,24 @@ public:
     }
 };
 } //  Namespace xp
+using xp::thread;
+#if defined(__MINGW32__) && !defined(_GLIBCXX_HAS_GTHREADS)
 } //  Namespace mingw_stdthread
 
 namespace std
 {
-using ::mingw_stdthread::xp::thread;
+using ::mingw_stdthread::thread;
+#else
+#pragma message("This version of MinGW seems to include a win32 port of pthreads\
+, and probably already has C++11 std threading classes implemented, based on\
+ pthreads. If you would still like to use this implementation (as it is more\
+ lightweight), you can use the classes in namespace mingw_stdthread, rather than\
+ those in std.")
+#endif
 
 namespace this_thread
 {
-  inline std::thread::id get_id()
+  inline thread::id get_id()
   {
 //    If, for some reason (such as a programmer editing this file), std::thread
 //  and ::mingw_stdthread::xp::thread are different, this will emit a
@@ -194,7 +194,10 @@ namespace this_thread
     sleep_for(sleep_time-Clock::now());
   }
 }
+}
 
+namespace std
+{
 //  Specialization of templates is allowed in namespace std.
 template<>
 struct hash<typename ::mingw_stdthread::xp::thread::id>

--- a/mingw.thread.h
+++ b/mingw.thread.h
@@ -47,7 +47,7 @@
 #define _STD_THREAD_INVALID_HANDLE nullptr
 namespace mingw_stdthread
 {
-namespace win32
+namespace xp
 {
 class thread
 {
@@ -164,21 +164,21 @@ public:
         mThreadId.clear();
     }
 };
-} //  Namespace win32
+} //  Namespace xp
 } //  Namespace mingw_stdthread
 
 namespace std
 {
-using ::mingw_stdthread::win32::thread;
+using ::mingw_stdthread::xp::thread;
 
 namespace this_thread
 {
   inline std::thread::id get_id()
   {
 //    If, for some reason (such as a programmer editing this file), std::thread
-//  and ::mingw_stdthread::win32::thread are different, this will emit a
+//  and ::mingw_stdthread::xp::thread are different, this will emit a
 //  compiler error, rather than allowing incorrect behavior.
-    return ::mingw_stdthread::win32::thread::id(GetCurrentThreadId());
+    return ::mingw_stdthread::xp::thread::id(GetCurrentThreadId());
   }
   inline void yield() {
     Sleep(0);
@@ -197,9 +197,9 @@ namespace this_thread
 
 //  Specialization of templates is allowed in namespace std.
 template<>
-struct hash<typename ::mingw_stdthread::win32::thread::id>
+struct hash<typename ::mingw_stdthread::xp::thread::id>
 {
-  typedef typename ::mingw_stdthread::win32::thread::id argument_type;
+  typedef typename ::mingw_stdthread::xp::thread::id argument_type;
   typedef size_t result_type;
   size_t operator() (const argument_type & i) const noexcept
   {
@@ -211,9 +211,9 @@ struct hash<typename ::mingw_stdthread::win32::thread::id>
 template< class CharT, class Traits >
 std::basic_ostream<CharT,Traits>&
     operator<<( std::basic_ostream<CharT,Traits>& ost,
-               typename ::mingw_stdthread::win32::thread::id id )
+               typename mingw_stdthread::xp::thread::id id )
 {
-  std::hash<typename std::thread::id> hasher;
+  std::hash<typename mingw_stdthread::xp::thread::id> hasher;
   ost << hasher(id);
   return ost;
 }


### PR DESCRIPTION
This branch provides better standard compliance for thread::id, a shared_mutex implementation, and high-performance condition variables for Vista (selected automatically based on target Windows version). Windows version is determined via the WINVER macro. To compile for alternate versions of Windows, use "-D _WIN32_WINNT=...". See [Modifying WINVER and _WIN32_WINNT](https://msdn.microsoft.com/en-us/library/6sehtctf.aspx) for constants corresponding to Windows versions.
- To elegantly support implementations at multiple feature levels, I have moved all non-template classes to namespace mingw_stdthread and its sub-namespaces mingw_stdthread::portable, mingw_stdthread::xp, mingw_stdthread::vista, mingw_stdthread::windows7, depending on necessary Windows feature set (none, XP, Vista, and Windows 7, respectively). Interaction between boundaries can then select efficient implementations, if available, using ADL.
- Best available implementations are added to namespace std by means of using declarations.
- Implements hash, serialization, and all comparisons for thread::id, improving standard compliance.
- Updates mingw.condition_variable.h with a native Windows implementation of condition_variable and condition_variable_any. These are automatically brought into namespace std if Vista features are supported. If Vista features are not supported, then the original (XP-compatible) implementation is used instead.
- Adds mingw.shared_mutex.h, which fully implements the C++14 and C++17 features. Automatically selects whether to use Windows features (Win7+) or a portable atomics-based implemetation (XP, Vista, non-Windows). The native class is defined with partial implementation at Vista feature level, or fully at Windows 7 feature level.