### PR TITLE
Fix condition_variable[_any]::wait_{until|for} helpers with predicate

### DIFF
--- a/mingw.thread.h
+++ b/mingw.thread.h
@@ -27,6 +27,7 @@
 #include <system_error>
 #include <cerrno>
 #include <process.h>
+#include <ostream>
 
 #ifdef _GLIBCXX_HAS_GTHREADS
 #error This version of MinGW seems to include a win32 port of pthreads, and probably    \
@@ -62,6 +63,16 @@ public:
         friend bool operator<=(id x, id y) noexcept {return x.mId <= y.mId; }
         friend bool operator> (id x, id y) noexcept {return x.mId >  y.mId; }
         friend bool operator>=(id x, id y) noexcept {return x.mId >= y.mId; }
+
+        template<class _CharT, class _Traits>
+        friend std::basic_ostream<_CharT, _Traits>&
+        operator<<(std::basic_ostream<_CharT, _Traits>& __out, id __id) {
+            if (__id == id()) {
+                return __out << "thread::id of a non-executing thread";
+            } else {
+                return __out << __id.mId;
+            }
+        }
     };
 protected:
     HANDLE mHandle;

--- a/mingw.thread.h
+++ b/mingw.thread.h
@@ -56,7 +56,12 @@ public:
         friend class thread;
     public:
         explicit id(DWORD aId=0) noexcept : mId(aId){}
-        bool operator==(const id& other) const {return mId == other.mId;}
+        friend bool operator==(id x, id y) noexcept {return x.mId == y.mId; }
+        friend bool operator!=(id x, id y) noexcept {return x.mId != y.mId; }
+        friend bool operator< (id x, id y) noexcept {return x.mId <  y.mId; }
+        friend bool operator<=(id x, id y) noexcept {return x.mId <= y.mId; }
+        friend bool operator> (id x, id y) noexcept {return x.mId >  y.mId; }
+        friend bool operator>=(id x, id y) noexcept {return x.mId >= y.mId; }
     };
 protected:
     HANDLE mHandle;

--- a/mingw.thread.h
+++ b/mingw.thread.h
@@ -55,7 +55,7 @@ public:
         void clear() {mId = 0;}
         friend class thread;
     public:
-        explicit id(DWORD aId=0):mId(aId){}
+        explicit id(DWORD aId=0) noexcept : mId(aId){}
         bool operator==(const id& other) const {return mId == other.mId;}
     };
 protected:
@@ -156,8 +156,8 @@ public:
 
 namespace this_thread
 {
-    inline thread::id get_id() {return thread::id(GetCurrentThreadId());}
-    inline void yield() {Sleep(0);}
+    inline thread::id get_id() noexcept {return thread::id(GetCurrentThreadId());}
+    inline void yield() noexcept {Sleep(0);}
     template< class Rep, class Period >
     void sleep_for( const std::chrono::duration<Rep,Period>& sleep_duration)
     {

--- a/mingw.thread.h
+++ b/mingw.thread.h
@@ -146,17 +146,20 @@ public:
         std::swap(mHandle, other.mHandle);
         std::swap(mThreadId.mId, other.mThreadId.mId);
     }
+
+    static unsigned int _hardware_concurrency_helper() noexcept
+    {
+        SYSTEM_INFO sysinfo;
+        ::GetSystemInfo(&sysinfo);
+        return sysinfo.dwNumberOfProcessors;
+    }
+
     static unsigned int hardware_concurrency() noexcept
     {
-        static int ncpus = -1;
-        if (ncpus == -1)
-        {
-            SYSTEM_INFO sysinfo;
-            GetSystemInfo(&sysinfo);
-            ncpus = sysinfo.dwNumberOfProcessors;
-        }
-        return ncpus;
+        static unsigned int cached = _hardware_concurrency_helper();
+        return cached;
     }
+
     void detach()
     {
         if (!joinable())


### PR DESCRIPTION
The `condition_variable_any::wait_{until|for}` overloads taking a
predicate incorrectly just called `wait_{until|for}` *without* a predicate
and just checked if the predicate was true on exit. This is incorrect,
as the very point of the with-predicate overloads is that they should:

- check if the predicate is already verified and not even wait if it is;
- automatically retry at every wakeup if the predicate is not verified
  (typically done for spurious wakeups), and quit if:
  - the predicate is verified;
  - the given timeout expired.

This commit fixes the situation: `wait_for(lock, rel_time, pred)` and
`wait_until(lock, abs_time, pred)` are simply replaced with their
definitions straight from the C++ standard (C++11, §30.5.2 ¶20 and ¶25),
that ultimately define them in terms of `wait_until(lock, abs_time)`.

Even though at low level the implementation works with a timeout
(instead of a fixed time point limit), using `wait_until` even to
implement `wait_for` is necessary because we want our timeout to be
relative to the moment when the initial `wait_for` was issued, without
renewing the timeout for each wakeup.