### PR TITLE
Various thread id standard conforming fixes

### DIFF
--- a/mingw.thread.h
+++ b/mingw.thread.h
@@ -27,6 +27,7 @@
 #include <system_error>
 #include <cerrno>
 #include <process.h>
+#include <ostream>
 
 #ifdef _GLIBCXX_HAS_GTHREADS
 #error This version of MinGW seems to include a win32 port of pthreads, and probably    \
@@ -62,6 +63,16 @@ public:
         friend bool operator<=(id x, id y) noexcept {return x.mId <= y.mId; }
         friend bool operator> (id x, id y) noexcept {return x.mId >  y.mId; }
         friend bool operator>=(id x, id y) noexcept {return x.mId >= y.mId; }
+
+        template<class _CharT, class _Traits>
+        friend std::basic_ostream<_CharT, _Traits>&
+        operator<<(std::basic_ostream<_CharT, _Traits>& __out, id __id) {
+            if (__id == id()) {
+                return __out << "thread::id of a non-executing thread";
+            } else {
+                return __out << __id.mId;
+            }
+        }
     };
 protected:
     HANDLE mHandle;

--- a/mingw.thread.h
+++ b/mingw.thread.h
@@ -56,7 +56,12 @@ public:
         friend class thread;
     public:
         explicit id(DWORD aId=0) noexcept : mId(aId){}
-        bool operator==(const id& other) const {return mId == other.mId;}
+        friend bool operator==(id x, id y) noexcept {return x.mId == y.mId; }
+        friend bool operator!=(id x, id y) noexcept {return x.mId != y.mId; }
+        friend bool operator< (id x, id y) noexcept {return x.mId <  y.mId; }
+        friend bool operator<=(id x, id y) noexcept {return x.mId <= y.mId; }
+        friend bool operator> (id x, id y) noexcept {return x.mId >  y.mId; }
+        friend bool operator>=(id x, id y) noexcept {return x.mId >= y.mId; }
     };
 protected:
     HANDLE mHandle;

--- a/mingw.thread.h
+++ b/mingw.thread.h
@@ -55,7 +55,7 @@ public:
         void clear() {mId = 0;}
         friend class thread;
     public:
-        explicit id(DWORD aId=0):mId(aId){}
+        explicit id(DWORD aId=0) noexcept : mId(aId){}
         bool operator==(const id& other) const {return mId == other.mId;}
     };
 protected:
@@ -156,8 +156,8 @@ public:
 
 namespace this_thread
 {
-    inline thread::id get_id() {return thread::id(GetCurrentThreadId());}
-    inline void yield() {Sleep(0);}
+    inline thread::id get_id() noexcept {return thread::id(GetCurrentThreadId());}
+    inline void yield() noexcept {Sleep(0);}
     template< class Rep, class Period >
     void sleep_for( const std::chrono::duration<Rep,Period>& sleep_duration)
     {


### PR DESCRIPTION
Fixed various nonconforming bits:

- added several missing `noexcept` specifiers;
- fixed `std::thread::id::operator==` (the standard mandates it to be a free function);
- added missing operators on `std::thread::id` (allow it to be used as a key in a `std::map`).