### PR TITLE
std::thread::hardware_concurrency: avoid race conditions in initialization

### DIFF
--- a/mingw.thread.h
+++ b/mingw.thread.h
@@ -130,17 +130,20 @@ public:
         std::swap(mHandle, other.mHandle);
         std::swap(mThreadId.mId, other.mThreadId.mId);
     }
+
+    static unsigned int _hardware_concurrency_helper() noexcept
+    {
+        SYSTEM_INFO sysinfo;
+        ::GetSystemInfo(&sysinfo);
+        return sysinfo.dwNumberOfProcessors;
+    }
+
     static unsigned int hardware_concurrency() noexcept
     {
-        static int ncpus = -1;
-        if (ncpus == -1)
-        {
-            SYSTEM_INFO sysinfo;
-            GetSystemInfo(&sysinfo);
-            ncpus = sysinfo.dwNumberOfProcessors;
-        }
-        return ncpus;
+        static unsigned int cached = _hardware_concurrency_helper();
+        return cached;
     }
+
     void detach()
     {
         if (!joinable())


### PR DESCRIPTION
Use direct initialization from a function to the static variable to
leverage the implicit locking provided by the compiler. This avoids the
(very theoretical) race condition of concurrent initialization;
shouldn't matter on x86 (where all `DWORD` stores are atomic), may matter
on other architectures.