### PR TITLE
Add hash for thread::id

### DIFF
--- a/mingw.thread.h
+++ b/mingw.thread.h
@@ -56,6 +56,7 @@ public:
         DWORD mId;
         void clear() {mId = 0;}
         friend class thread;
+        friend class hash<id>;
     public:
         explicit id(DWORD aId=0) noexcept : mId(aId){}
         friend bool operator==(id x, id y) noexcept {return x.mId == y.mId; }
@@ -193,6 +194,18 @@ namespace this_thread
         sleep_for(sleep_time-Clock::now());
     }
 }
+
+//  Specialization of templates is allowed in namespace std.
+template<>
+struct hash<thread::id>
+{
+    typedef thread::id argument_type;
+    typedef size_t result_type;
+    size_t operator() (const argument_type & i) const noexcept
+    {
+        return i.mId;
+    }
+};
 
 }
 #endif // WIN32STDTHREAD_H

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -5,6 +5,7 @@
 #include "../mingw.condition_variable.h"
 #include <atomic>
 #include <assert.h>
+#include <iostream>
 
 using namespace std;
 
@@ -20,6 +21,10 @@ void test_call_once(int a, const char* str)
 
 int main()
 {
+    LOG("Testing serialization and hashing for thread::id...");
+    std::cout << "Serialization:\t" << this_thread::get_id() << "\n";
+    std::hash<thread::id> hasher;
+    std::cout << "Hash:\t" << hasher(this_thread::get_id()) << "\n";
     std::thread t([](bool a, const char* b, int c)mutable
     {
         try


### PR DESCRIPTION
- Adds specialization of the `hash` class template for `thread::id`
objects., to comply with the standard.
- Adds tests for serialization and hashing to `tests.cpp`.