### PR TITLE
Header shared_mutex

### DIFF
--- a/mingw.shared_mutex.h
+++ b/mingw.shared_mutex.h
@@ -1,0 +1,486 @@
+/// \file mingw.shared_mutex.h
+/// \brief Standard-compliant shared_mutex for MinGW
+///
+/// (c) 2017 by Nathaniel J. McClatchey, Athens OH, United States
+/// \author Nathaniel J. McClatchey
+///
+/// \copyright Simplified (2-clause) BSD License.
+///
+/// \note This file may become part of the mingw-w64 runtime package. If/when
+/// this happens, the appropriate license will be added, i.e. this code will
+/// become dual-licensed, and the current BSD 2-clause license will stay.
+/// \note Target Windows version is determined by WINVER, which is determined in
+/// <windows.h> from _WIN32_WINNT, which can itself be set by the user.
+
+//  Notes on the namespaces:
+//  - The implementation can be accessed directly in the namespace
+//    mingw_stdthread.
+//  - Objects will be brought into namespace std by a using directive. This
+//    will cause objects declared in std (such as MinGW's implementation) to
+//    hide this implementation's definitions.
+//  - To avoid poluting the namespace with implementation details, all objects
+//    to be pushed into std will be placed in mingw_stdthread::visible.
+//  The end result is that if MinGW supplies an object, it is automatically
+//  used. If MinGW does not supply an object, this implementation's version will
+//  instead be used.
+
+#ifndef MINGW_SHARED_MUTEX_H_
+#define MINGW_SHARED_MUTEX_H_
+
+#if !defined(__cplusplus) || (__cplusplus < 201103L)
+#error A C++11 compiler is required!
+#endif
+
+#include <assert.h>
+
+//    Use MinGW's shared_lock class template, if it's available. Requires C++14.
+//  If unavailable (eg. because this library is being used in C++11), then an
+//  implementation of shared_lock is provided by this header.
+#if (__cplusplus >= 201402L)
+#include <shared_mutex>
+#else
+//  For defer_lock_t, adopt_lock_t, and try_to_lock_t
+#include <mutex>
+#endif
+
+//  For descriptive errors.
+#include <system_error>
+//    Implementing a shared_mutex without OS support will require atomic read-
+//  modify-write capacity.
+#include <atomic>
+//  For timing in shared_lock and shared_timed_mutex.
+#include <chrono>
+
+//  For this_thread::yield.
+#include "mingw.thread.h"
+
+//  Might be able to use native Slim Reader-Writer (SRW) locks.
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+namespace mingw_stdthread
+{
+//  Define a portable atomics-based shared_mutex
+namespace portable
+{
+class shared_mutex
+{
+    typedef uint_fast16_t counter_type;
+    std::atomic<counter_type> mCounter;
+    static constexpr counter_type kWriteBit = 1 << (sizeof(counter_type) * CHAR_BIT - 1);
+public:
+    typedef shared_mutex * native_handle_type;
+
+    shared_mutex ()
+        : mCounter(0)
+    {
+    }
+
+//  No form of copying or moving should be allowed.
+    shared_mutex (const shared_mutex&) = delete;
+    shared_mutex & operator= (const shared_mutex&) = delete;
+
+    ~shared_mutex ()
+    {
+//  Terminate if someone tries to destroy an owned mutex.
+        assert(mCounter.load(std::memory_order_relaxed) == 0);
+    }
+
+    void lock_shared (void)
+    {
+        counter_type expected = mCounter.load(std::memory_order_relaxed);
+        do
+        {
+//  Delay if writing or if too many readers are attempting to read.
+            if (expected >= kWriteBit - 1)
+            {
+                using namespace std;
+                using namespace this_thread;
+                yield();
+                expected = mCounter.load(std::memory_order_relaxed);
+                continue;
+            }
+            if (mCounter.compare_exchange_weak(expected, expected + 1,
+                                               std::memory_order_acquire,
+                                               std::memory_order_relaxed))
+                break;
+        }
+        while (true);
+    }
+
+    bool try_lock_shared (void)
+    {
+        counter_type expected = mCounter.load(std::memory_order_relaxed) & (~kWriteBit);
+        if (expected + 1 == kWriteBit)
+            return false;
+        else
+            return mCounter.compare_exchange_strong( expected, expected + 1,
+                                                    std::memory_order_acquire,
+                                                    std::memory_order_relaxed);
+    }
+
+    void unlock_shared (void)
+    {
+        using namespace std;
+#ifndef NDEBUG
+        if (!(mCounter.fetch_sub(1, memory_order_release) & (~kWriteBit)))
+            throw system_error(make_error_code(errc::operation_not_permitted));
+#else
+        mCounter.fetch_sub(1, memory_order_release);
+#endif
+    }
+
+//  Behavior is undefined if a lock was previously acquired.
+    void lock (void)
+    {
+        using namespace std;
+        using namespace this_thread;
+//  Might be able to use relaxed memory order...
+//  Wait for the write-lock to be unlocked, then claim the write slot.
+        counter_type current;
+        while ((current = mCounter.fetch_or(kWriteBit, std::memory_order_acquire)) & kWriteBit)
+            yield();
+//  Wait for readers to finish up.
+        while (current != kWriteBit)
+        {
+            yield();
+            current = mCounter.load(std::memory_order_acquire);
+        }
+    }
+
+    bool try_lock (void)
+    {
+        counter_type expected = 0;
+        return mCounter.compare_exchange_strong(expected, kWriteBit,
+                                                std::memory_order_acquire,
+                                                std::memory_order_relaxed);
+    }
+
+    void unlock (void)
+    {
+        using namespace std;
+#ifndef NDEBUG
+        if (mCounter.load(memory_order_relaxed) != kWriteBit)
+            throw system_error(make_error_code(errc::operation_not_permitted));
+#endif
+        mCounter.store(0, memory_order_release);
+    }
+
+    native_handle_type native_handle (void)
+    {
+        return this;
+    }
+};
+
+} //  Namespace portable
+
+//    The native shared_mutex implementation primarily uses features of Windows
+//  Vista, but the features used for try_lock and try_lock_shared were not
+//  introduced until Windows 7. To allow limited use while compiling for Vista,
+//  I define the class without try_* functions in that case.
+//    Only fully-featured implementations will be placed into namespace std.
+#if defined(_WIN32) && (WINVER >= _WIN32_WINNT_VISTA)
+namespace windows7
+{
+class shared_mutex
+{
+    SRWLOCK mHandle;
+public:
+    typedef PSRWLOCK native_handle_type;
+
+    shared_mutex ()
+        : mHandle()
+    {
+        InitializeSRWLock(&mHandle);
+    }
+
+    ~shared_mutex () = default;
+
+//  No form of copying or moving should be allowed.
+    shared_mutex (const shared_mutex&) = delete;
+    shared_mutex & operator= (const shared_mutex&) = delete;
+
+//  Behavior is undefined if a lock was previously acquired by this thread.
+    void lock (void)
+    {
+        AcquireSRWLockExclusive(&mHandle);
+    }
+
+    void lock_shared (void)
+    {
+        AcquireSRWLockShared(&mHandle);
+    }
+
+    void unlock_shared (void)
+    {
+        ReleaseSRWLockShared(&mHandle);
+    }
+
+    void unlock (void)
+    {
+        ReleaseSRWLockExclusive(&mHandle);
+    }
+
+//  TryAcquireSRW functions are a Windows 7 feature.
+#if (WINVER >= _WIN32_WINNT_WIN7)
+    bool try_lock_shared (void)
+    {
+        return TryAcquireSRWLockShared(&mHandle) != 0;
+    }
+
+    bool try_lock (void)
+    {
+        return TryAcquireSRWLockExclusive(&mHandle) != 0;
+    }
+#endif
+
+    native_handle_type native_handle (void)
+    {
+        return &mHandle;
+    }
+};
+
+} //  Namespace windows7
+#endif  //  Compiling for Vista
+#if (defined(_WIN32) && (WINVER >= _WIN32_WINNT_WIN7))
+using windows7::shared_mutex;
+#else
+using portable::shared_mutex;
+#endif
+
+class shared_timed_mutex : protected shared_mutex
+{
+    typedef shared_mutex Base;
+public:
+    using Base::lock;
+    using Base::try_lock;
+    using Base::unlock;
+    using Base::lock_shared;
+    using Base::try_lock_shared;
+    using Base::unlock_shared;
+
+    template< class Clock, class Duration >
+    bool try_lock_until ( const std::chrono::time_point<Clock,Duration>& cutoff )
+    {
+        do
+        {
+            if (try_lock())
+                return true;
+        }
+        while (std::chrono::steady_clock::now() < cutoff);
+        return false;
+    }
+
+    template< class Rep, class Period >
+    bool try_lock_for (const std::chrono::duration<Rep,Period>& rel_time)
+    {
+        return try_lock_until(std::chrono::steady_clock::now() + rel_time);
+    }
+
+    template< class Clock, class Duration >
+    bool try_lock_shared_until ( const std::chrono::time_point<Clock,Duration>& cutoff )
+    {
+        do
+        {
+            if (try_lock_shared())
+                return true;
+        }
+        while (std::chrono::steady_clock::now() < cutoff);
+        return false;
+    }
+
+    template< class Rep, class Period >
+    bool try_lock_shared_for (const std::chrono::duration<Rep,Period>& rel_time)
+    {
+        return try_lock_shared_until(std::chrono::steady_clock::now() + rel_time);
+    }
+};
+
+//    Pull lock adoption types into scope, while allowing implementation-defined
+//  lock adoption types.
+using namespace std;
+
+//    If not supplied by shared_mutex (eg. because C++17 is not supported), I
+//  supply the various helper classes that the header should have defined.
+template<class Mutex>
+class shared_lock
+{
+    Mutex * mMutex;
+    bool mOwns;
+//  Reduce code redundancy
+    void verify_lockable (void)
+    {
+        if (mMutex == nullptr)
+            throw system_error(make_error_code(errc::operation_not_permitted));
+        if (mOwns)
+            throw system_error(make_error_code(errc::resource_deadlock_would_occur));
+    }
+public:
+    typedef Mutex mutex_type;
+
+    shared_lock (void) noexcept
+        : mMutex(nullptr), mOwns(false)
+    {
+    }
+
+    shared_lock (shared_lock<Mutex> && other) noexcept
+        : mMutex(other.mutex_), mOwns(other.owns_)
+    {
+        other.mMutex = nullptr;
+        other.mOwns = false;
+    }
+
+    explicit shared_lock (mutex_type & m)
+        : mMutex(&m), mOwns(true)
+    {
+        mMutex->lock_shared();
+    }
+
+    shared_lock (mutex_type & m, defer_lock_t) noexcept
+        : mMutex(&m), mOwns(false)
+    {
+    }
+
+    shared_lock (mutex_type & m, adopt_lock_t)
+        : mMutex(&m), mOwns(true)
+    {
+    }
+
+    shared_lock (mutex_type & m, try_to_lock_t)
+        : mMutex(&m), mOwns(m.try_lock_shared())
+    {
+    }
+
+    template< class Rep, class Period >
+    shared_lock( mutex_type& m, const chrono::duration<Rep,Period>& timeout_duration )
+        : mMutex(&m), mOwns(m.try_lock_shared_for(timeout_duration))
+    {
+    }
+
+    template< class Clock, class Duration >
+    shared_lock( mutex_type& m, const chrono::time_point<Clock,Duration>& timeout_time )
+        : mMutex(&m), mOwns(m.try_lock_shared_until(timeout_time))
+    {
+    }
+
+    shared_lock& operator= (shared_lock<Mutex> && other) noexcept
+    {
+        if (&other != this)
+        {
+            if (mOwns)
+                mMutex->unlock_shared();
+            mMutex = other.mMutex;
+            mOwns = other.mOwns;
+            other.mMutex = nullptr;
+            other.mOwns = false;
+        }
+        return *this;
+    }
+
+
+    ~shared_lock (void)
+    {
+        if (mOwns)
+            mMutex->unlock_shared();
+    }
+
+    shared_lock (const shared_lock<Mutex> &) = delete;
+    shared_lock& operator= (const shared_lock<Mutex> &) = delete;
+
+//  Shared locking
+    void lock (void)
+    {
+        verify_lockable();
+        mMutex->lock_shared();
+        mOwns = true;
+    }
+
+    bool try_lock (void)
+    {
+        verify_lockable();
+        mOwns = mMutex->try_lock_shared();
+        return mOwns;
+    }
+
+    template< class Clock, class Duration >
+    bool try_lock_until( const chrono::time_point<Clock,Duration>& cutoff )
+    {
+        verify_lockable();
+        do
+        {
+            mOwns = mMutex->try_lock_shared();
+            if (mOwns)
+                return mOwns;
+        }
+        while (chrono::steady_clock::now() < cutoff);
+        return false;
+    }
+
+    template< class Rep, class Period >
+    bool try_lock_for (const chrono::duration<Rep,Period>& rel_time)
+    {
+        return try_lock_until(chrono::steady_clock::now() + rel_time);
+    }
+
+    void unlock (void)
+    {
+        if (!mOwns)
+            throw system_error(make_error_code(errc::operation_not_permitted));
+        mMutex->unlock_shared();
+        mOwns = false;
+    }
+
+//  Modifiers
+    void swap (shared_lock<Mutex> & other) noexcept
+    {
+        swap(mMutex, other.mMutex);
+        swap(mOwns, other.mOwns);
+    }
+
+    mutex_type * release (void) noexcept
+    {
+        mutex_type * ptr = mMutex;
+        mMutex = nullptr;
+        mOwns = false;
+        return ptr;
+    }
+//  Observers
+    mutex_type * mutex (void) const noexcept
+    {
+        return mMutex;
+    }
+
+    bool owns_lock (void) const noexcept
+    {
+        return mOwns;
+    }
+
+    explicit operator bool () const noexcept
+    {
+        return owns_lock();
+    }
+};
+
+//    Pushing objects into std:: via a using directive (eg. using namespace ...)
+//  will cause this implementation's objects to be hidden if they are already
+//  supplied by MinGW, even without preprocessor tricks.
+namespace visible
+{
+using mingw_stdthread::shared_mutex;
+using mingw_stdthread::shared_timed_mutex;
+using mingw_stdthread::shared_lock;
+
+template< class Mutex >
+void swap( shared_lock<Mutex>& lhs, shared_lock<Mutex>& rhs ) noexcept
+{
+    lhs.swap(rhs);
+}
+} //  Namespace visible.
+} //  Namespace mingw_stdthread
+
+namespace std
+{
+using namespace mingw_stdthread::visible;
+} //  Namespace std
+#endif // MINGW_SHARED_MUTEX_H_


### PR DESCRIPTION
- Adds all classes that are intended to be supplied by <shared_mutex>.
- Adds tests for `shared_mutex`, `shared_lock`, `condition_variable_any`.

Notable features:
- Selects implementation (native or portable) based on target Windows version.
- Various namespace tricks provide conditional inclusion. Implementation files are brought into `std` if and only if `std` doesn't supply them. Unlike preprocessor-based solutions, this should be compatible with the practice of including a header inside a namespace. For example,
`namespace tmp {
#include "mingw.shared_mutex.h"
}`
will cause the implementation to place objects in namespace `tmp::std`, regardless of the presence of an official implementation in `std`, while
`#include "mingw.shared_mutex.h"`
will cause the implementation to place objects in namespace `std` only if they would not override what is already there.
- The aforementioned practice of placing headers inside namespaces is now unnecessary (and discouraged) due to the implementation being placed in a namespace `mingw_stdthread`.