### PR TITLE
Make use alongside standard implementations safe

### DIFF
--- a/mingw.condition_variable.h
+++ b/mingw.condition_variable.h
@@ -20,6 +20,9 @@
 
 #ifndef MINGW_CONDITIONAL_VARIABLE_H
 #define MINGW_CONDITIONAL_VARIABLE_H
+//  Use the standard classes for std::, if available.
+#include <condition_variable>
+
 #include <atomic>
 #include <assert.h>
 #include "mingw.mutex.h"
@@ -196,19 +199,20 @@ public:
     bool wait_until (unique_lock<mutex>& lock, const std::chrono::time_point<Clock, Duration>& abs_time, Predicate pred)
     {        return base::wait_until(lock, abs_time, pred); }
 };
-
-//  Contains only those objects that ought to be placed in std.
-namespace visible
-{
-using mingw_stdthread::cv_status;
-using mingw_stdthread::condition_variable;
-using mingw_stdthread::condition_variable_any;
-} //  Namespace mingw_stdthread::visible
 } //  Namespace mingw_stdthread
 
 //  Push objects into std, but only if they are not already there.
 namespace std
 {
-using namespace mingw_stdthread::visible;
+//    Because of quirks of the compiler, the common "using namespace std;"
+//  directive would flatten the namespaces and introduce ambiguity where there
+//  was none. Direct specification (std::), however, would be unaffected.
+//    Take the safe option, and include only in the presence of MinGW's win32
+//  implementation.
+#if defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS)
+using mingw_stdthread::cv_status;
+using mingw_stdthread::condition_variable;
+using mingw_stdthread::condition_variable_any;
+#endif
 }
 #endif // MINGW_CONDITIONAL_VARIABLE_H

--- a/mingw.condition_variable.h
+++ b/mingw.condition_variable.h
@@ -52,7 +52,7 @@ protected:
     bool wait_impl(M& lock, DWORD timeout)
     {
         {
-            std::lock_guard<recursive_mutex> guard(mMutex);
+            lock_guard<recursive_mutex> guard(mMutex);
             mNumWaiters++;
         }
         lock.unlock();
@@ -96,7 +96,7 @@ public:
 
     void notify_all() noexcept
     {
-        std::lock_guard<recursive_mutex> lock(mMutex); //block any further wait requests until all current waiters are unblocked
+        lock_guard<recursive_mutex> lock(mMutex); //block any further wait requests until all current waiters are unblocked
         if (mNumWaiters.load() <= 0)
             return;
 
@@ -117,7 +117,7 @@ public:
     }
     void notify_one() noexcept
     {
-        std::lock_guard<recursive_mutex> lock(mMutex);
+        lock_guard<recursive_mutex> lock(mMutex);
         int targetWaiters = mNumWaiters.load() - 1;
         if (targetWaiters <= -1)
             return;
@@ -178,22 +178,22 @@ public:
     using base::base;
     using base::notify_all;
     using base::notify_one;
-    void wait(std::unique_lock<mutex> &lock)
+    void wait(unique_lock<mutex> &lock)
     {       base::wait(lock);                               }
     template <class Predicate>
-    void wait(std::unique_lock<mutex>& lock, Predicate pred)
+    void wait(unique_lock<mutex>& lock, Predicate pred)
     {       base::wait(lock, pred);                         }
     template <class Rep, class Period>
-    cv_status wait_for(std::unique_lock<mutex>& lock, const std::chrono::duration<Rep, Period>& rel_time)
+    cv_status wait_for(unique_lock<mutex>& lock, const std::chrono::duration<Rep, Period>& rel_time)
     {      return base::wait_for(lock, rel_time);           }
     template <class Rep, class Period, class Predicate>
-    bool wait_for(std::unique_lock<mutex>& lock, const std::chrono::duration<Rep, Period>& rel_time, Predicate pred)
+    bool wait_for(unique_lock<mutex>& lock, const std::chrono::duration<Rep, Period>& rel_time, Predicate pred)
     {        return base::wait_for(lock, rel_time, pred);   }
     template <class Clock, class Duration>
-    cv_status wait_until (std::unique_lock<mutex>& lock, const std::chrono::time_point<Clock,Duration>& abs_time)
+    cv_status wait_until (unique_lock<mutex>& lock, const std::chrono::time_point<Clock,Duration>& abs_time)
     {        return base::wait_until(lock, abs_time);         }
     template <class Clock, class Duration, class Predicate>
-    bool wait_until (std::unique_lock<mutex>& lock, const std::chrono::time_point<Clock, Duration>& abs_time, Predicate pred)
+    bool wait_until (unique_lock<mutex>& lock, const std::chrono::time_point<Clock, Duration>& abs_time, Predicate pred)
     {        return base::wait_until(lock, abs_time, pred); }
 };
 

--- a/mingw.mutex.h
+++ b/mingw.mutex.h
@@ -43,6 +43,18 @@
 
 namespace mingw_stdthread
 {
+//    To make this namespace equivalent to the thread-related subset of std,
+//  pull in the classes and class templates supplied by std but not by this
+//  implementation.
+using std::lock_guard;
+using std::unique_lock;
+using std::adopt_lock_t;
+using std::defer_lock_t;
+using std::try_to_lock_t;
+using std::adopt_lock;
+using std::defer_lock;
+using std::try_to_lock;
+
 class recursive_mutex
 {
 protected:
@@ -247,14 +259,13 @@ void call_once(once_flag& flag, Callable&& func, Args&&... args)
 {
     if (flag.mHasRun.load(std::memory_order_acquire))
         return;
-    std::lock_guard<mutex> lock(flag.mMutex);
+    lock_guard<mutex> lock(flag.mMutex);
     if (flag.mHasRun.load(std::memory_order_acquire))
         return;
     //std::invoke seems to be not defined at least in some cases
     func(std::forward<Args>(args)...);
     flag.mHasRun.store(true, std::memory_order_release);
 }
-
 //  Contains only those objects that ought to be placed in std.
 namespace visible
 {

--- a/mingw.mutex.h
+++ b/mingw.mutex.h
@@ -266,19 +266,21 @@ void call_once(once_flag& flag, Callable&& func, Args&&... args)
     func(std::forward<Args>(args)...);
     flag.mHasRun.store(true, std::memory_order_release);
 }
-//  Contains only those objects that ought to be placed in std.
-namespace visible
-{
-using mingw_stdthread::recursive_mutex;
-using mingw_stdthread::mutex;
-using mingw_stdthread::once_flag;
-using mingw_stdthread::call_once;
-}
 } //  Namespace mingw_stdthread
 
 //  Push objects into std, but only if they are not already there.
 namespace std
 {
-using namespace mingw_stdthread::visible;
+//    Because of quirks of the compiler, the common "using namespace std;"
+//  directive would flatten the namespaces and introduce ambiguity where there
+//  was none. Direct specification (std::), however, would be unaffected.
+//    Take the safe option, and include only in the presence of MinGW's win32
+//  implementation.
+#if defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS)
+using mingw_stdthread::recursive_mutex;
+using mingw_stdthread::mutex;
+using mingw_stdthread::once_flag;
+using mingw_stdthread::call_once;
+#endif
 }
 #endif // WIN32STDMUTEX_H

--- a/mingw.shared_mutex.h
+++ b/mingw.shared_mutex.h
@@ -479,8 +479,10 @@ namespace std
 //  was none. Direct specification (std::), however, would be unaffected.
 //    Take the safe option, and include only in the presence of MinGW's win32
 //  implementation.
-#if (__cplusplus < 201402L) || (defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS))
+#if (__cplusplus < 201703L) || (defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS))
 using mingw_stdthread::shared_mutex;
+#endif
+#if (__cplusplus < 201402L) || (defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS))
 using mingw_stdthread::shared_timed_mutex;
 using mingw_stdthread::shared_lock;
 #endif

--- a/mingw.shared_mutex.h
+++ b/mingw.shared_mutex.h
@@ -40,7 +40,7 @@
 #include <shared_mutex>
 #else
 //  For defer_lock_t, adopt_lock_t, and try_to_lock_t
-#include <mutex>
+#include "mingw.mutex.h"
 #endif
 
 //  For descriptive errors.
@@ -463,27 +463,26 @@ public:
         return owns_lock();
     }
 };
-#endif  //  C++11
-
-//    Pushing objects into std:: via a using directive (eg. using namespace ...)
-//  will cause this implementation's objects to be hidden if they are already
-//  supplied by MinGW, even without preprocessor tricks.
-namespace visible
-{
-using mingw_stdthread::shared_mutex;
-using mingw_stdthread::shared_timed_mutex;
-using mingw_stdthread::shared_lock;
 
 template< class Mutex >
 void swap( shared_lock<Mutex>& lhs, shared_lock<Mutex>& rhs ) noexcept
 {
     lhs.swap(rhs);
 }
-} //  Namespace mingw_stdthread::visible
+#endif  //  C++11
 } //  Namespace mingw_stdthread
 
 namespace std
 {
-using namespace mingw_stdthread::visible;
+//    Because of quirks of the compiler, the common "using namespace std;"
+//  directive would flatten the namespaces and introduce ambiguity where there
+//  was none. Direct specification (std::), however, would be unaffected.
+//    Take the safe option, and include only in the presence of MinGW's win32
+//  implementation.
+#if (__cplusplus < 201402L) || (defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS))
+using mingw_stdthread::shared_mutex;
+using mingw_stdthread::shared_timed_mutex;
+using mingw_stdthread::shared_lock;
+#endif
 } //  Namespace std
 #endif // MINGW_SHARED_MUTEX_H_

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -1,6 +1,5 @@
 #undef _GLIBCXX_HAS_GTHREADS
 #include "../mingw.thread.h"
-#include <mutex>
 #include "../mingw.mutex.h"
 #include "../mingw.condition_variable.h"
 #include "../mingw.shared_mutex.h"
@@ -8,6 +7,7 @@
 #include <assert.h>
 #include <string>
 #include <iostream>
+#include <windows.h>
 
 using namespace std;
 
@@ -73,8 +73,10 @@ int main()
         try
         {
             LOG("Worker thread started, sleeping for a while...");
-            assert(a.mStr == "move test moved" && !strcmp(b, "test message")
-               && (c == -20));
+//  Thread might move the string more than once.
+            assert(a.mStr.substr(0, 15) == "move test moved");
+            assert(!strcmp(b, "test message"));
+            assert(c == -20);
             auto move2nd = std::move(a); //test move to final destination
             this_thread::sleep_for(std::chrono::milliseconds(5000));
             {


### PR DESCRIPTION
- Moves the implementation to its own namespace, `mingw_stdthread`, and removes the `#error` that occurs when including the implementation alongside GCC's implementation. This makes simultaneous inclusion of both implementations safe.
- Removes the namespace inclusion trick from `mingw.shared_mutex.h`. No ambiguity occurred when objects specified a namespace with `std::`, but `using namespace std;` fully flattens the namespace tree, which could have introduced ambiguity.
- Added a check for the presence of MinGW before including files into `std`. This should allow the library to be used as-is with Visual Studio, etc., but might cause `custom_namespace::std` to be empty if the header is included inside `custom_namespace`. To achieve compatibility with legacy code with minimal changes, one could rename the `mingw.*.h` headers and create new headers like the following:
`#include "mingw.*.h"
namespace std {
using namespace mingw_stdthread;
}`.
These compatibility headers would clash with namespace `std` (if `using namespace std;` is declared, and if not included in their own namespace), but can safely be included inside a custom namespace.
- Fixes a test in `tests.cpp`. The original test would fail unless an object was moved exactly once. The standard library moves the object multiple times, which would cause the test to fail. The new test allows repeated movement.