### PR TITLE
Native condition_variable if targeting Windows Vista

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ on MinGW GCC.
 Windows compatibility
 =====================
 This implementation should work with Windows XP (regardless of service pack), or newer.
-Since Vista, Windows has native condition variables, but we do not rely on them, to keep compatibility
-with Windows XP.
+The library automatically detects the version of Windows that is being targeted, and selects an implementation that takes advantage of available Windows features. In MinGW GCC, the target Windows version may optionally be selected by the command-line option `-D _WIN32_WINNT=...`. Use `0x0600` for Windows Vista, or `0x0601` for Windows 7. See ["Modifying `WINVER` and `_WIN32_WINNT`](https://docs.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt).
 
 Usage
 =====

--- a/mingw.condition_variable.h
+++ b/mingw.condition_variable.h
@@ -20,6 +20,9 @@
 
 #ifndef MINGW_CONDITIONAL_VARIABLE_H
 #define MINGW_CONDITIONAL_VARIABLE_H
+//  Use the standard classes for std::, if available.
+#include <condition_variable>
+
 #include <atomic>
 #include <assert.h>
 #include "mingw.mutex.h"
@@ -196,19 +199,20 @@ public:
     bool wait_until (unique_lock<mutex>& lock, const std::chrono::time_point<Clock, Duration>& abs_time, Predicate pred)
     {        return base::wait_until(lock, abs_time, pred); }
 };
-
-//  Contains only those objects that ought to be placed in std.
-namespace visible
-{
-using mingw_stdthread::cv_status;
-using mingw_stdthread::condition_variable;
-using mingw_stdthread::condition_variable_any;
-} //  Namespace mingw_stdthread::visible
 } //  Namespace mingw_stdthread
 
 //  Push objects into std, but only if they are not already there.
 namespace std
 {
-using namespace mingw_stdthread::visible;
+//    Because of quirks of the compiler, the common "using namespace std;"
+//  directive would flatten the namespaces and introduce ambiguity where there
+//  was none. Direct specification (std::), however, would be unaffected.
+//    Take the safe option, and include only in the presence of MinGW's win32
+//  implementation.
+#if defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS)
+using mingw_stdthread::cv_status;
+using mingw_stdthread::condition_variable;
+using mingw_stdthread::condition_variable_any;
+#endif
 }
 #endif // MINGW_CONDITIONAL_VARIABLE_H

--- a/mingw.condition_variable.h
+++ b/mingw.condition_variable.h
@@ -25,14 +25,21 @@
 
 #include <atomic>
 #include <assert.h>
-#include "mingw.mutex.h"
 #include <chrono>
 #include <system_error>
 #include <windows.h>
+#include "mingw.mutex.h"
+#include "mingw.shared_mutex.h"
 
 namespace mingw_stdthread
 {
+#if defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS)
 enum class cv_status { no_timeout, timeout };
+#else
+using std::cv_status;
+#endif
+namespace xp
+{
 class condition_variable_any
 {
 protected:
@@ -42,14 +49,21 @@ protected:
     HANDLE mWakeEvent;
 public:
     typedef HANDLE native_handle_type;
-    native_handle_type native_handle() {return mSemaphore;}
+    native_handle_type native_handle()
+    {
+        return mSemaphore;
+    }
     condition_variable_any(const condition_variable_any&) = delete;
     condition_variable_any& operator=(const condition_variable_any&) = delete;
     condition_variable_any()
         :mNumWaiters(0), mSemaphore(CreateSemaphore(NULL, 0, 0xFFFF, NULL)),
          mWakeEvent(CreateEvent(NULL, FALSE, FALSE, NULL))
     {}
-    ~condition_variable_any() {  CloseHandle(mWakeEvent); CloseHandle(mSemaphore);  }
+    ~condition_variable_any()
+    {
+        CloseHandle(mWakeEvent);
+        CloseHandle(mSemaphore);
+    }
 protected:
     template <class M>
     bool wait_impl(M& lock, DWORD timeout)
@@ -59,7 +73,7 @@ protected:
             mNumWaiters++;
         }
         lock.unlock();
-            DWORD ret = WaitForSingleObject(mSemaphore, timeout);
+        DWORD ret = WaitForSingleObject(mSemaphore, timeout);
 
         mNumWaiters--;
         SetEvent(mWakeEvent);
@@ -135,9 +149,10 @@ public:
     }
     template <class M, class Rep, class Period>
     cv_status wait_for(M& lock,
-      const std::chrono::duration<Rep, Period>& rel_time)
+                       const std::chrono::duration<Rep, Period>& rel_time)
     {
-        long long timeout = std::chrono::duration_cast<std::chrono::milliseconds>(rel_time).count();
+        using namespace std::chrono;
+        long long timeout = duration_cast<milliseconds>(rel_time).count();
         if (timeout < 0)
             timeout = 0;
         bool ret = wait_impl(lock, (DWORD)timeout);
@@ -146,20 +161,20 @@ public:
 
     template <class M, class Rep, class Period, class Predicate>
     bool wait_for(M& lock,
-       const std::chrono::duration<Rep, Period>& rel_time, Predicate pred)
+                  const std::chrono::duration<Rep, Period>& rel_time, Predicate pred)
     {
         return wait_until(lock, std::chrono::steady_clock::now()+rel_time, pred);
     }
     template <class M, class Clock, class Duration>
     cv_status wait_until (M& lock,
-      const std::chrono::time_point<Clock,Duration>& abs_time)
+                          const std::chrono::time_point<Clock,Duration>& abs_time)
     {
         return wait_for(lock, abs_time - Clock::now());
     }
     template <class M, class Clock, class Duration, class Predicate>
     bool wait_until (M& lock,
-      const std::chrono::time_point<Clock, Duration>& abs_time,
-      Predicate pred)
+                     const std::chrono::time_point<Clock, Duration>& abs_time,
+                     Predicate pred)
     {
         while (!pred())
         {
@@ -182,23 +197,275 @@ public:
     using base::notify_all;
     using base::notify_one;
     void wait(unique_lock<mutex> &lock)
-    {       base::wait(lock);                               }
+    {
+        base::wait(lock);
+    }
     template <class Predicate>
     void wait(unique_lock<mutex>& lock, Predicate pred)
-    {       base::wait(lock, pred);                         }
+    {
+        base::wait(lock, pred);
+    }
     template <class Rep, class Period>
     cv_status wait_for(unique_lock<mutex>& lock, const std::chrono::duration<Rep, Period>& rel_time)
-    {      return base::wait_for(lock, rel_time);           }
+    {
+        return base::wait_for(lock, rel_time);
+    }
     template <class Rep, class Period, class Predicate>
     bool wait_for(unique_lock<mutex>& lock, const std::chrono::duration<Rep, Period>& rel_time, Predicate pred)
-    {        return base::wait_for(lock, rel_time, pred);   }
+    {
+        return base::wait_for(lock, rel_time, pred);
+    }
     template <class Clock, class Duration>
     cv_status wait_until (unique_lock<mutex>& lock, const std::chrono::time_point<Clock,Duration>& abs_time)
-    {        return base::wait_until(lock, abs_time);         }
+    {
+        return base::wait_until(lock, abs_time);
+    }
     template <class Clock, class Duration, class Predicate>
     bool wait_until (unique_lock<mutex>& lock, const std::chrono::time_point<Clock, Duration>& abs_time, Predicate pred)
-    {        return base::wait_until(lock, abs_time, pred); }
+    {
+        return base::wait_until(lock, abs_time, pred);
+    }
 };
+} //  Namespace mingw_stdthread::xp
+
+#if (WINVER >= _WIN32_WINNT_VISTA)
+namespace vista
+{
+//  If compiling for Vista or higher, use the native condition variable.
+class condition_variable
+{
+protected:
+    CONDITION_VARIABLE cvariable_;
+
+    bool wait_impl (unique_lock<mutex> & lock, DWORD time)
+    {
+        static_assert(std::is_same<typename mutex::native_handle_type, PCRITICAL_SECTION>::value,
+                      "Native Win32 condition variable requires std::mutex to use  \
+                   native Win32 critical section objects.");
+        mutex * pmutex = lock.release();
+#ifndef STDMUTEX_NO_RECURSION_CHECKS
+#if (__cplusplus < 201402L)
+        if (pmutex->mOwnerThread != GetCurrentThreadId())
+            throw std::system_error(std::make_error_code(std::errc::resource_deadlock_would_occur));
+#endif
+        pmutex->mOwnerThread = 0;
+#endif
+        BOOL success = SleepConditionVariableCS(&cvariable_,
+                                                pmutex->native_handle(),
+                                                time);
+#ifndef STDMUTEX_NO_RECURSION_CHECKS
+        pmutex->mOwnerThread = GetCurrentThreadId();
+#endif
+        lock = unique_lock<mutex>(*pmutex, adopt_lock);
+        return success;
+    }
+public:
+    typedef PCONDITION_VARIABLE native_handle_type;
+    native_handle_type native_handle (void)
+    {
+        return &cvariable_;
+    }
+
+    condition_variable (void)
+        : cvariable_()
+    {
+        InitializeConditionVariable(&cvariable_);
+    }
+
+    ~condition_variable (void) = default;
+
+    condition_variable (const condition_variable &) = delete;
+    condition_variable & operator= (const condition_variable &) = delete;
+
+    void notify_one (void) noexcept
+    {
+        WakeConditionVariable(&cvariable_);
+    }
+
+    void notify_all (void) noexcept
+    {
+        WakeAllConditionVariable(&cvariable_);
+    }
+
+    void wait (unique_lock<mutex> & lock)
+    {
+        wait_impl(lock, INFINITE);
+    }
+
+    template<class Predicate>
+    void wait (unique_lock<mutex> & lock, Predicate pred)
+    {
+        while (!pred())
+            wait(lock);
+    }
+
+    template <class Rep, class Period>
+    cv_status wait_for(unique_lock<mutex>& lock,
+                       const std::chrono::duration<Rep, Period>& rel_time)
+    {
+        using namespace std::chrono;
+        auto time = duration_cast<milliseconds>(rel_time).count();
+        if (time < 0)
+            time = 0;
+        bool result = wait_impl(lock, static_cast<DWORD>(time));
+        return result ? cv_status::no_timeout : cv_status::timeout;
+    }
+
+    template <class Rep, class Period, class Predicate>
+    bool wait_for(unique_lock<mutex>& lock,
+                  const std::chrono::duration<Rep, Period>& rel_time,
+                  Predicate pred)
+    {
+        return wait_until(lock,
+                          std::chrono::steady_clock::now() + rel_time,
+                          std::move(pred));
+    }
+    template <class Clock, class Duration>
+    cv_status wait_until (unique_lock<mutex>& lock,
+                          const std::chrono::time_point<Clock,Duration>& abs_time)
+    {
+        return wait_for(lock, abs_time - Clock::now());
+    }
+    template <class Clock, class Duration, class Predicate>
+    bool wait_until  (unique_lock<mutex>& lock,
+                      const std::chrono::time_point<Clock, Duration>& abs_time,
+                      Predicate pred)
+    {
+        while (!pred())
+        {
+            if (wait_until(lock, abs_time) == cv_status::timeout)
+            {
+                return pred();
+            }
+        }
+        return true;
+    }
+};
+
+class condition_variable_any : protected condition_variable
+{
+protected:
+    typedef condition_variable base;
+    typedef windows7::shared_mutex native_shared_mutex;
+
+    mutex internal_mutex_;
+
+    template<class L>
+    bool wait_impl (L & lock, DWORD time)
+    {
+        unique_lock<mutex> internal_lock(internal_mutex_);
+        lock.unlock();
+        bool success = base::wait_impl(internal_lock, time);
+        lock.lock();
+        return success;
+    }
+//    If the lock happens to be called on a native Windows mutex, skip any extra
+//  contention.
+    inline bool wait_impl (unique_lock<mutex> & lock, DWORD time)
+    {
+        return base::wait_impl(lock, time);
+    }
+//    Some shared_mutex functionality is available even in Vista, but it's not
+//  until Windows 7 that a full implementation is natively possible. The class
+//  itself is defined, with missing features, at the Vista feature level.
+//#if (WINVER >= _WIN32_WINNT_VISTA)
+    bool wait_impl (unique_lock<native_shared_mutex> & lock, DWORD time)
+    {
+        static_assert(CONDITION_VARIABLE_LOCKMODE_SHARED != 0,
+                  "Flag CONDITION_VARIABLE_LOCKMODE_SHARED is not defined as   \
+                  expected. Flag for exclusive mode is unknown (not specified  \
+                  by Microsoft Dev Center).");
+        native_shared_mutex * pmutex = lock.release();
+        BOOL success = SleepConditionVariableSRW( base::native_handle(),
+                       pmutex->native_handle(), time, 0);
+        lock = unique_lock<native_shared_mutex>(*pmutex, adopt_lock);
+        return success;
+    }
+    bool wait_impl (shared_lock<native_shared_mutex> & lock, DWORD time)
+    {
+        native_shared_mutex * pmutex = lock.release();
+        BOOL success = SleepConditionVariableSRW( base::native_handle(),
+                       pmutex->native_handle(), time,
+                       CONDITION_VARIABLE_LOCKMODE_SHARED);
+        lock = shared_lock<native_shared_mutex>(*pmutex, adopt_lock);
+        return success;
+    }
+//#endif
+public:
+    typedef typename base::native_handle_type native_handle_type;
+    using base::native_handle;
+
+    condition_variable_any (void)
+        : base(), internal_mutex_()
+    {
+    }
+
+    ~condition_variable_any (void) = default;
+
+    using base::notify_one;
+    using base::notify_all;
+
+    template<class L>
+    void wait (L & lock)
+    {
+        wait_impl(lock, INFINITE);
+    }
+
+    template<class L, class Predicate>
+    void wait (L & lock, Predicate pred)
+    {
+        while (!pred())
+            wait(lock);
+    }
+
+    template <class L, class Rep, class Period>
+    cv_status wait_for(L& lock, const std::chrono::duration<Rep, Period>& period)
+    {
+        using namespace std::chrono;
+        auto time = duration_cast<milliseconds>(period).count();
+        if (time < 0)
+            time = 0;
+        bool result = wait_impl(lock, static_cast<DWORD>(time));
+        return result ? cv_status::no_timeout : cv_status::timeout;
+    }
+
+    template <class L, class Rep, class Period, class Predicate>
+    bool wait_for(L& lock, const std::chrono::duration<Rep, Period>& period,
+                  Predicate pred)
+    {
+        return wait_until(lock, std::chrono::steady_clock::now() + period,
+                          std::move(pred));
+    }
+    template <class L, class Clock, class Duration>
+    cv_status wait_until (L& lock,
+                          const std::chrono::time_point<Clock,Duration>& abs_time)
+    {
+        return wait_for(lock, abs_time - Clock::now());
+    }
+    template <class L, class Clock, class Duration, class Predicate>
+    bool wait_until  (L& lock,
+                      const std::chrono::time_point<Clock, Duration>& abs_time,
+                      Predicate pred)
+    {
+        while (!pred())
+        {
+            if (wait_until(lock, abs_time) == cv_status::timeout)
+            {
+                return pred();
+            }
+        }
+        return true;
+    }
+};
+} //  Namespace vista
+#endif
+#if WINVER < 0x0600
+using xp::condition_variable;
+using xp::condition_variable_any;
+#else
+using vista::condition_variable;
+using vista::condition_variable_any;
+#endif
 } //  Namespace mingw_stdthread
 
 //  Push objects into std, but only if they are not already there.

--- a/mingw.condition_variable.h
+++ b/mingw.condition_variable.h
@@ -20,6 +20,10 @@
 
 #ifndef MINGW_CONDITIONAL_VARIABLE_H
 #define MINGW_CONDITIONAL_VARIABLE_H
+
+#if !defined(__cplusplus) || (__cplusplus < 201103L)
+#error A C++11 compiler is required!
+#endif
 //  Use the standard classes for std::, if available.
 #include <condition_variable>
 
@@ -56,7 +60,8 @@ public:
     condition_variable_any(const condition_variable_any&) = delete;
     condition_variable_any& operator=(const condition_variable_any&) = delete;
     condition_variable_any()
-        :mNumWaiters(0), mSemaphore(CreateSemaphore(NULL, 0, 0xFFFF, NULL)),
+        :mMutex(), mNumWaiters(0),
+         mSemaphore(CreateSemaphore(NULL, 0, 0xFFFF, NULL)),
          mWakeEvent(CreateEvent(NULL, FALSE, FALSE, NULL))
     {}
     ~condition_variable_any()

--- a/mingw.condition_variable.h
+++ b/mingw.condition_variable.h
@@ -52,7 +52,7 @@ protected:
     bool wait_impl(M& lock, DWORD timeout)
     {
         {
-            std::lock_guard<recursive_mutex> guard(mMutex);
+            lock_guard<recursive_mutex> guard(mMutex);
             mNumWaiters++;
         }
         lock.unlock();
@@ -96,7 +96,7 @@ public:
 
     void notify_all() noexcept
     {
-        std::lock_guard<recursive_mutex> lock(mMutex); //block any further wait requests until all current waiters are unblocked
+        lock_guard<recursive_mutex> lock(mMutex); //block any further wait requests until all current waiters are unblocked
         if (mNumWaiters.load() <= 0)
             return;
 
@@ -117,7 +117,7 @@ public:
     }
     void notify_one() noexcept
     {
-        std::lock_guard<recursive_mutex> lock(mMutex);
+        lock_guard<recursive_mutex> lock(mMutex);
         int targetWaiters = mNumWaiters.load() - 1;
         if (targetWaiters <= -1)
             return;
@@ -178,22 +178,22 @@ public:
     using base::base;
     using base::notify_all;
     using base::notify_one;
-    void wait(std::unique_lock<mutex> &lock)
+    void wait(unique_lock<mutex> &lock)
     {       base::wait(lock);                               }
     template <class Predicate>
-    void wait(std::unique_lock<mutex>& lock, Predicate pred)
+    void wait(unique_lock<mutex>& lock, Predicate pred)
     {       base::wait(lock, pred);                         }
     template <class Rep, class Period>
-    cv_status wait_for(std::unique_lock<mutex>& lock, const std::chrono::duration<Rep, Period>& rel_time)
+    cv_status wait_for(unique_lock<mutex>& lock, const std::chrono::duration<Rep, Period>& rel_time)
     {      return base::wait_for(lock, rel_time);           }
     template <class Rep, class Period, class Predicate>
-    bool wait_for(std::unique_lock<mutex>& lock, const std::chrono::duration<Rep, Period>& rel_time, Predicate pred)
+    bool wait_for(unique_lock<mutex>& lock, const std::chrono::duration<Rep, Period>& rel_time, Predicate pred)
     {        return base::wait_for(lock, rel_time, pred);   }
     template <class Clock, class Duration>
-    cv_status wait_until (std::unique_lock<mutex>& lock, const std::chrono::time_point<Clock,Duration>& abs_time)
+    cv_status wait_until (unique_lock<mutex>& lock, const std::chrono::time_point<Clock,Duration>& abs_time)
     {        return base::wait_until(lock, abs_time);         }
     template <class Clock, class Duration, class Predicate>
-    bool wait_until (std::unique_lock<mutex>& lock, const std::chrono::time_point<Clock, Duration>& abs_time, Predicate pred)
+    bool wait_until (unique_lock<mutex>& lock, const std::chrono::time_point<Clock, Duration>& abs_time, Predicate pred)
     {        return base::wait_until(lock, abs_time, pred); }
 };
 

--- a/mingw.condition_variable.h
+++ b/mingw.condition_variable.h
@@ -485,6 +485,14 @@ namespace std
 using mingw_stdthread::cv_status;
 using mingw_stdthread::condition_variable;
 using mingw_stdthread::condition_variable_any;
+#elif !defined(MINGW_STDTHREAD_REDUNDANCY_WARNING)  //  Skip repetition
+#define MINGW_STDTHREAD_REDUNDANCY_WARNING
+#pragma message "This version of MinGW seems to include a win32 port of\
+ pthreads, and probably already has C++11 std threading classes implemented,\
+ based on pthreads. These classes, found in namespace std, are not overridden\
+ by the mingw-std-thread library. If you would still like to use this\
+ implementation (as it is more lightweight), use the classes provided in\
+ namespace mingw_stdthread."
 #endif
 }
 #endif // MINGW_CONDITIONAL_VARIABLE_H

--- a/mingw.mutex.h
+++ b/mingw.mutex.h
@@ -298,6 +298,14 @@ using mingw_stdthread::recursive_mutex;
 using mingw_stdthread::mutex;
 using mingw_stdthread::once_flag;
 using mingw_stdthread::call_once;
+#elif !defined(MINGW_STDTHREAD_REDUNDANCY_WARNING)  //  Skip repetition
+#define MINGW_STDTHREAD_REDUNDANCY_WARNING
+#pragma message "This version of MinGW seems to include a win32 port of\
+ pthreads, and probably already has C++11 std threading classes implemented,\
+ based on pthreads. These classes, found in namespace std, are not overridden\
+ by the mingw-std-thread library. If you would still like to use this\
+ implementation (as it is more lightweight), use the classes provided in\
+ namespace mingw_stdthread."
 #endif
 }
 #endif // WIN32STDMUTEX_H

--- a/mingw.mutex.h
+++ b/mingw.mutex.h
@@ -43,6 +43,15 @@
 
 namespace mingw_stdthread
 {
+//    The _NonRecursive class has mechanisms that do not play nice with direct
+//  manipulation of the native handle. This forward declaration is part of
+//  a friend class declaration.
+#ifndef STDMUTEX_NO_RECURSION_CHECKS
+namespace vista
+{
+class condition_variable;
+}
+#endif
 //    To make this namespace equivalent to the thread-related subset of std,
 //  pull in the classes and class templates supplied by std but not by this
 //  implementation.
@@ -89,6 +98,10 @@ template <class B>
 class _NonRecursive: protected B
 {
 protected:
+#ifndef STDMUTEX_NO_RECURSION_CHECKS
+//    Allow condition variable to unlock the native handle directly.
+    friend class vista::condition_variable;
+#endif
     typedef B base;
     DWORD mOwnerThread;
 public:

--- a/mingw.mutex.h
+++ b/mingw.mutex.h
@@ -43,6 +43,18 @@
 
 namespace mingw_stdthread
 {
+//    To make this namespace equivalent to the thread-related subset of std,
+//  pull in the classes and class templates supplied by std but not by this
+//  implementation.
+using std::lock_guard;
+using std::unique_lock;
+using std::adopt_lock_t;
+using std::defer_lock_t;
+using std::try_to_lock_t;
+using std::adopt_lock;
+using std::defer_lock;
+using std::try_to_lock;
+
 class recursive_mutex
 {
 protected:
@@ -247,14 +259,13 @@ void call_once(once_flag& flag, Callable&& func, Args&&... args)
 {
     if (flag.mHasRun.load(std::memory_order_acquire))
         return;
-    std::lock_guard<mutex> lock(flag.mMutex);
+    lock_guard<mutex> lock(flag.mMutex);
     if (flag.mHasRun.load(std::memory_order_acquire))
         return;
     //std::invoke seems to be not defined at least in some cases
     func(std::forward<Args>(args)...);
     flag.mHasRun.store(true, std::memory_order_release);
 }
-
 //  Contains only those objects that ought to be placed in std.
 namespace visible
 {

--- a/mingw.mutex.h
+++ b/mingw.mutex.h
@@ -296,6 +296,8 @@ namespace std
 #if defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS)
 using mingw_stdthread::recursive_mutex;
 using mingw_stdthread::mutex;
+using mingw_stdthread::recursive_timed_mutex;
+using mingw_stdthread::timed_mutex;
 using mingw_stdthread::once_flag;
 using mingw_stdthread::call_once;
 #elif !defined(MINGW_STDTHREAD_REDUNDANCY_WARNING)  //  Skip repetition

--- a/mingw.mutex.h
+++ b/mingw.mutex.h
@@ -266,19 +266,21 @@ void call_once(once_flag& flag, Callable&& func, Args&&... args)
     func(std::forward<Args>(args)...);
     flag.mHasRun.store(true, std::memory_order_release);
 }
-//  Contains only those objects that ought to be placed in std.
-namespace visible
-{
-using mingw_stdthread::recursive_mutex;
-using mingw_stdthread::mutex;
-using mingw_stdthread::once_flag;
-using mingw_stdthread::call_once;
-}
 } //  Namespace mingw_stdthread
 
 //  Push objects into std, but only if they are not already there.
 namespace std
 {
-using namespace mingw_stdthread::visible;
+//    Because of quirks of the compiler, the common "using namespace std;"
+//  directive would flatten the namespaces and introduce ambiguity where there
+//  was none. Direct specification (std::), however, would be unaffected.
+//    Take the safe option, and include only in the presence of MinGW's win32
+//  implementation.
+#if defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS)
+using mingw_stdthread::recursive_mutex;
+using mingw_stdthread::mutex;
+using mingw_stdthread::once_flag;
+using mingw_stdthread::call_once;
+#endif
 }
 #endif // WIN32STDMUTEX_H

--- a/mingw.mutex.h
+++ b/mingw.mutex.h
@@ -19,6 +19,10 @@
 
 #ifndef WIN32STDMUTEX_H
 #define WIN32STDMUTEX_H
+
+#if !defined(__cplusplus) || (__cplusplus < 201103L)
+#error A C++11 compiler is required!
+#endif
 // Recursion checks on non-recursive locks have some performance penalty, so the user
 // may want to disable the checks in release builds. In that case, make sure they
 // are always enabled in debug builds.
@@ -71,7 +75,7 @@ protected:
 public:
     typedef LPCRITICAL_SECTION native_handle_type;
     native_handle_type native_handle() {return &mHandle;}
-    recursive_mutex() noexcept
+    recursive_mutex() noexcept : mHandle()
     {
         InitializeCriticalSection(&mHandle);
     }
@@ -263,7 +267,7 @@ class once_flag
     template<class Callable, class... Args>
     friend void call_once(once_flag& once, Callable&& f, Args&&... args);
 public:
-    constexpr once_flag() noexcept: mHasRun(false) {}
+    constexpr once_flag() noexcept: mMutex(), mHasRun(false) {}
 
 };
 

--- a/mingw.shared_mutex.h
+++ b/mingw.shared_mutex.h
@@ -479,8 +479,10 @@ namespace std
 //  was none. Direct specification (std::), however, would be unaffected.
 //    Take the safe option, and include only in the presence of MinGW's win32
 //  implementation.
-#if (__cplusplus < 201402L) || (defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS))
+#if (__cplusplus < 201703L) || (defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS))
 using mingw_stdthread::shared_mutex;
+#endif
+#if (__cplusplus < 201402L) || (defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS))
 using mingw_stdthread::shared_timed_mutex;
 using mingw_stdthread::shared_lock;
 #endif

--- a/mingw.shared_mutex.h
+++ b/mingw.shared_mutex.h
@@ -484,6 +484,14 @@ using mingw_stdthread::shared_mutex;
 #if (__cplusplus < 201402L) || (defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS))
 using mingw_stdthread::shared_timed_mutex;
 using mingw_stdthread::shared_lock;
+#elif !defined(MINGW_STDTHREAD_REDUNDANCY_WARNING)  //  Skip repetition
+#define MINGW_STDTHREAD_REDUNDANCY_WARNING
+#pragma message "This version of MinGW seems to include a win32 port of\
+ pthreads, and probably already has C++ std threading classes implemented,\
+ based on pthreads. These classes, found in namespace std, are not overridden\
+ by the mingw-std-thread library. If you would still like to use this\
+ implementation (as it is more lightweight), use the classes provided in\
+ namespace mingw_stdthread."
 #endif
 } //  Namespace std
 #endif // MINGW_SHARED_MUTEX_H_

--- a/mingw.shared_mutex.h
+++ b/mingw.shared_mutex.h
@@ -190,9 +190,8 @@ public:
     typedef PSRWLOCK native_handle_type;
 
     shared_mutex ()
-        : mHandle()
+        : mHandle(SRWLOCK_INIT)
     {
-        InitializeSRWLock(&mHandle);
     }
 
     ~shared_mutex () = default;

--- a/mingw.shared_mutex.h
+++ b/mingw.shared_mutex.h
@@ -40,7 +40,7 @@
 #include <shared_mutex>
 #else
 //  For defer_lock_t, adopt_lock_t, and try_to_lock_t
-#include <mutex>
+#include "mingw.mutex.h"
 #endif
 
 //  For descriptive errors.
@@ -463,27 +463,26 @@ public:
         return owns_lock();
     }
 };
-#endif  //  C++11
-
-//    Pushing objects into std:: via a using directive (eg. using namespace ...)
-//  will cause this implementation's objects to be hidden if they are already
-//  supplied by MinGW, even without preprocessor tricks.
-namespace visible
-{
-using mingw_stdthread::shared_mutex;
-using mingw_stdthread::shared_timed_mutex;
-using mingw_stdthread::shared_lock;
 
 template< class Mutex >
 void swap( shared_lock<Mutex>& lhs, shared_lock<Mutex>& rhs ) noexcept
 {
     lhs.swap(rhs);
 }
-} //  Namespace mingw_stdthread::visible
+#endif  //  C++11
 } //  Namespace mingw_stdthread
 
 namespace std
 {
-using namespace mingw_stdthread::visible;
+//    Because of quirks of the compiler, the common "using namespace std;"
+//  directive would flatten the namespaces and introduce ambiguity where there
+//  was none. Direct specification (std::), however, would be unaffected.
+//    Take the safe option, and include only in the presence of MinGW's win32
+//  implementation.
+#if (__cplusplus < 201402L) || (defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS))
+using mingw_stdthread::shared_mutex;
+using mingw_stdthread::shared_timed_mutex;
+using mingw_stdthread::shared_lock;
+#endif
 } //  Namespace std
 #endif // MINGW_SHARED_MUTEX_H_

--- a/mingw.thread.h
+++ b/mingw.thread.h
@@ -20,6 +20,10 @@
 #ifndef WIN32STDTHREAD_H
 #define WIN32STDTHREAD_H
 
+#if !defined(__cplusplus) || (__cplusplus < 201103L)
+#error A C++11 compiler is required!
+#endif
+
 //  Use the standard classes for std::, if available.
 #include <thread>
 
@@ -53,8 +57,8 @@ namespace detail
     struct ThreadFuncCall
     {
       typedef std::tuple<Args...> Tuple;
-      Tuple mArgs;
       Func mFunc;
+      Tuple mArgs;
       ThreadFuncCall(Func&& aFunc, Args&&... aArgs)
       :mFunc(std::forward<Func>(aFunc)), mArgs(std::forward<Args>(aArgs)...){}
       template <int... S>
@@ -105,7 +109,7 @@ public:
     typedef HANDLE native_handle_type;
     id get_id() const noexcept {return mThreadId;}
     native_handle_type native_handle() const {return mHandle;}
-    thread(): mHandle(_STD_THREAD_INVALID_HANDLE){}
+    thread(): mHandle(_STD_THREAD_INVALID_HANDLE), mThreadId(){}
 
     thread(thread&& other)
     :mHandle(other.mHandle), mThreadId(other.mThreadId)
@@ -117,7 +121,7 @@ public:
     thread(const thread &other)=delete;
 
     template<class Func, typename... Args>
-    explicit thread(Func&& func, Args&&... args)
+    explicit thread(Func&& func, Args&&... args) : mHandle(), mThreadId()
     {
         typedef detail::ThreadFuncCall<Func, Args...> Call;
         auto call = new Call(

--- a/mingw.thread.h
+++ b/mingw.thread.h
@@ -234,6 +234,14 @@ namespace this_thread
 {
 using namespace mingw_stdthread::this_thread;
 }
+#elif !defined(MINGW_STDTHREAD_REDUNDANCY_WARNING)  //  Skip repetition
+#define MINGW_STDTHREAD_REDUNDANCY_WARNING
+#pragma message "This version of MinGW seems to include a win32 port of\
+ pthreads, and probably already has C++11 std threading classes implemented,\
+ based on pthreads. These classes, found in namespace std, are not overridden\
+ by the mingw-std-thread library. If you would still like to use this\
+ implementation (as it is more lightweight), use the classes provided in\
+ namespace mingw_stdthread."
 #endif
 
 //    Specialize hash for this implementation's thread::id, even if the

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -34,27 +34,20 @@ struct TestMove
     }
 };
 
-static_assert(std::is_standard_layout<std::recursive_mutex>::value, "Class\
- std::recursive_mutex is required to satisfy the StandardLayoutType concept.");
-static_assert(std::is_standard_layout<std::recursive_timed_mutex>::value,\
- "Class std::recursive_mutex is required to satisfy the StandardLayoutType\
- concept.");
-#ifdef STDMUTEX_NO_RECURSION_CHECKS
-static_assert(std::is_standard_layout<std::mutex>::value, "Class std::mutex is\
- required to satisfy the StandardLayoutType concept.");
-static_assert(std::is_standard_layout<std::timed_mutex>::value, "Class\
- std::timed_mutex is required to satisfy the StandardLayoutType concept.");
-#else
-#pragma message "Non-recursive mutexes do not yet satisfy the StandardLayoutType\
- concept, which is required by the standard."
-#endif
-static_assert(std::is_standard_layout<std::shared_mutex>::value, "Class\
- std::shared_mutex is required to satisfy the StandardLayoutType concept.");
-static_assert(std::is_standard_layout<std::shared_timed_mutex>::value, "Class\
- std::shared_timed_mutex is required to satisfy the StandardLayoutType concept.");
-
 int main()
 {
+    if (!is_standard_layout<mutex>::value)
+      LOG("WARNING: Class std::%s does not satisfy concept StandardLayoutType.","mutex");
+    if (!is_standard_layout<recursive_mutex>::value)
+      LOG("WARNING: Class std::%s does not satisfy concept StandardLayoutType.","recursive_mutex");
+    if (!is_standard_layout<timed_mutex>::value)
+      LOG("WARNING: Class std::%s does not satisfy concept StandardLayoutType.","timed_mutex");
+    if (!is_standard_layout<recursive_timed_mutex>::value)
+      LOG("WARNING: Class std::%s does not satisfy concept StandardLayoutType.","recursive_timed_mutex");
+    if (!is_standard_layout<shared_mutex>::value)
+      LOG("WARNING: Class std::%s does not satisfy concept StandardLayoutType.","shared_mutex");
+    if (!is_standard_layout<shared_timed_mutex>::value)
+      LOG("WARNING: Class std::%s does not satisfy concept StandardLayoutType.","shared_timed_mutex");
 //    With C++ feature level and target Windows version potentially affecting
 //  behavior, make this information visible.
     {

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -29,7 +29,7 @@ struct TestMove
     TestMove(const std::string& aStr): mStr(aStr){}
     TestMove(TestMove&& other): mStr(other.mStr+" moved")
     { printf("%s: Object moved\n", mStr.c_str()); }
-    TestMove(const TestMove& other)
+    TestMove(const TestMove&) : mStr()
     {
         assert(false && "TestMove: Object COPIED instead of moved");
     }
@@ -48,6 +48,7 @@ int main()
             default: std::cout << "Compiled in a non-conforming C++ compiler";
         }
         std::cout << ", targeting Windows ";
+        static_assert(WINVER > 0x0500, "Windows NT and earlier are not supported.");
         switch (WINVER)
         {
             case 0x0501: std::cout << "XP"; break;
@@ -57,13 +58,13 @@ int main()
             case 0x0602: std::cout << "8"; break;
             case 0x0603: std::cout << "8.1"; break;
             case 0x0A00: std::cout << "10"; break;
-            default: std::cout << (WINVER > 0x0A00) ? "10+" : "NT or earlier";
+            default: std::cout << "10+";
         }
         std::cout << "\n";
     }
 
     {
-        LOG("Testing serialization and hashing for thread::id...");
+        LOG("%s","Testing serialization and hashing for thread::id...");
         std::cout << "Serialization:\t" << this_thread::get_id() << "\n";
         std::hash<thread::id> hasher;
         std::cout << "Hash:\t" << hasher(this_thread::get_id()) << "\n";
@@ -72,7 +73,7 @@ int main()
     {
         try
         {
-            LOG("Worker thread started, sleeping for a while...");
+            LOG("%s","Worker thread started, sleeping for a while...");
 //  Thread might move the string more than once.
             assert(a.mStr.substr(0, 15) == "move test moved");
             assert(!strcmp(b, "test message"));
@@ -82,7 +83,7 @@ int main()
             {
                 lock_guard<mutex> lock(m);
                 cond = 1;
-                LOG("Notifying condvar");
+                LOG("%s","Notifying condvar");
                 cv.notify_all();
             }
 
@@ -90,7 +91,7 @@ int main()
             {
                 lock_guard<decltype(sm)> lock(sm);
                 cond = 2;
-                LOG("Notifying condvar");
+                LOG("%s","Notifying condvar");
                 cv_any.notify_all();
             }
 
@@ -98,11 +99,11 @@ int main()
             {
                 lock_guard<decltype(sm)> lock(sm);
                 cond = 3;
-                LOG("Notifying condvar");
+                LOG("%s","Notifying condvar");
                 cv_any.notify_all();
             }
 
-            LOG("Worker thread finishing");
+            LOG("%s","Worker thread finishing");
         }
         catch(std::exception& e)
         {
@@ -112,31 +113,31 @@ int main()
     TestMove("move test"), "test message", -20);
     try
     {
-      LOG("Main thread: Locking mutex, waiting on condvar...");
+      LOG("%s","Main thread: Locking mutex, waiting on condvar...");
       {
           std::unique_lock<decltype(m)> lk(m);
           cv.wait(lk, []{ return cond >= 1;} );
           LOG("condvar notified, cond = %d", cond);
           assert(lk.owns_lock());
       }
-      LOG("Main thread: Locking shared_mutex, waiting on condvar...");
+      LOG("%s","Main thread: Locking shared_mutex, waiting on condvar...");
       {
           std::unique_lock<decltype(sm)> lk(sm);
           cv_any.wait(lk, []{ return cond >= 2;} );
           LOG("condvar notified, cond = %d", cond);
           assert(lk.owns_lock());
       }
-      LOG("Main thread: Locking shared_mutex in shared mode, waiting on condvar...");
+      LOG("%s","Main thread: Locking shared_mutex in shared mode, waiting on condvar...");
       {
           std::shared_lock<decltype(sm)> lk(sm);
           cv_any.wait(lk, []{ return cond >= 3;} );
           LOG("condvar notified, cond = %d", cond);
           assert(lk.owns_lock());
       }
-      LOG("Main thread: Waiting on worker join...");
+      LOG("%s","Main thread: Waiting on worker join...");
 
       t.join();
-      LOG("Main thread: Worker thread joined");
+      LOG("%s","Main thread: Worker thread joined");
       fflush(stdout);
     }
     catch(std::exception& e)
@@ -146,6 +147,6 @@ int main()
     once_flag of;
     call_once(of, test_call_once, 1, "test");
     call_once(of, test_call_once, 1, "ERROR! Should not be called second time");
-    LOG("Test complete");
+    LOG("%s","Test complete");
     return 0;
 }

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -1,6 +1,5 @@
 #undef _GLIBCXX_HAS_GTHREADS
 #include "../mingw.thread.h"
-#include <mutex>
 #include "../mingw.mutex.h"
 #include "../mingw.condition_variable.h"
 #include "../mingw.shared_mutex.h"
@@ -8,6 +7,7 @@
 #include <assert.h>
 #include <string>
 #include <iostream>
+#include <windows.h>
 
 using namespace std;
 
@@ -73,8 +73,10 @@ int main()
         try
         {
             LOG("Worker thread started, sleeping for a while...");
-            assert(a.mStr == "move test moved" && !strcmp(b, "test message")
-               && (c == -20));
+//  Thread might move the string more than once.
+            assert(a.mStr.substr(0, 15) == "move test moved");
+            assert(!strcmp(b, "test message"));
+            assert(c == -20);
             auto move2nd = std::move(a); //test move to final destination
             this_thread::sleep_for(std::chrono::milliseconds(5000));
             {

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -1,4 +1,3 @@
-#undef _GLIBCXX_HAS_GTHREADS
 #include "../mingw.thread.h"
 #include "../mingw.mutex.h"
 #include "../mingw.condition_variable.h"
@@ -34,6 +33,25 @@ struct TestMove
         assert(false && "TestMove: Object COPIED instead of moved");
     }
 };
+
+static_assert(std::is_standard_layout<std::recursive_mutex>::value, "Class\
+ std::recursive_mutex is required to satisfy the StandardLayoutType concept.");
+static_assert(std::is_standard_layout<std::recursive_timed_mutex>::value,\
+ "Class std::recursive_mutex is required to satisfy the StandardLayoutType\
+ concept.");
+#ifdef STDMUTEX_NO_RECURSION_CHECKS
+static_assert(std::is_standard_layout<std::mutex>::value, "Class std::mutex is\
+ required to satisfy the StandardLayoutType concept.");
+static_assert(std::is_standard_layout<std::timed_mutex>::value, "Class\
+ std::timed_mutex is required to satisfy the StandardLayoutType concept.");
+#else
+#pragma message "Non-recursive mutexes do not yet satisfy the StandardLayoutType\
+ concept, which is required by the standard."
+#endif
+static_assert(std::is_standard_layout<std::shared_mutex>::value, "Class\
+ std::shared_mutex is required to satisfy the StandardLayoutType concept.");
+static_assert(std::is_standard_layout<std::shared_timed_mutex>::value, "Class\
+ std::shared_timed_mutex is required to satisfy the StandardLayoutType concept.");
 
 int main()
 {


### PR DESCRIPTION
- Add native implementation of condition_variable if targeted Windows version is detected to be Vista or higher. This can noticeably improve performance.
- Update the README with information about how to target different Windows versions.