### PR TITLE
Refine detection of compiler and existence of std threading classes

### DIFF
--- a/mingw.condition_variable.h
+++ b/mingw.condition_variable.h
@@ -24,8 +24,6 @@
 #if !defined(__cplusplus) || (__cplusplus < 201103L)
 #error A C++11 compiler is required!
 #endif
-//  Use the standard classes for std::, if available.
-#include <condition_variable>
 
 #include <atomic>
 #include <assert.h>
@@ -486,13 +484,19 @@ using mingw_stdthread::cv_status;
 using mingw_stdthread::condition_variable;
 using mingw_stdthread::condition_variable_any;
 #elif !defined(MINGW_STDTHREAD_REDUNDANCY_WARNING)  //  Skip repetition
-#define MINGW_STDTHREAD_REDUNDANCY_WARNING
-#pragma message "This version of MinGW seems to include a win32 port of\
- pthreads, and probably already has C++11 std threading classes implemented,\
- based on pthreads. These classes, found in namespace std, are not overridden\
- by the mingw-std-thread library. If you would still like to use this\
- implementation (as it is more lightweight), use the classes provided in\
- namespace mingw_stdthread."
+  #define MINGW_STDTHREAD_REDUNDANCY_WARNING
+  #ifdef __MINGW32__
+    #pragma message "This version of MinGW seems to include a win32 port of\
+     pthreads, and probably already has C++11 std threading classes implemented,\
+     based on pthreads."
+  #else
+    #pragma message "You are using a non-MinGW compiler that probably already has std threading\
+     classes"
+  #endif
+  #pragma message "These classes, found in namespace std, are not overridden\
+   by the mingw-std-thread library. If you would still like to use this\
+   implementation (as it is more lightweight), the classes are provided in\
+   namespace mingw_stdthread."
 #endif
 }
 #endif // MINGW_CONDITIONAL_VARIABLE_H

--- a/mingw.mutex.h
+++ b/mingw.mutex.h
@@ -36,7 +36,7 @@
 #include <system_error>
 #include <cstdio>
 #include <atomic>
-#include <mutex> //need for call_once()
+#include <mutex> //need for lock_guard
 
 #ifndef EPROTO
     #define EPROTO 134
@@ -294,20 +294,26 @@ namespace std
 //    Take the safe option, and include only in the presence of MinGW's win32
 //  implementation.
 #if defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS)
-using mingw_stdthread::recursive_mutex;
-using mingw_stdthread::mutex;
-using mingw_stdthread::recursive_timed_mutex;
-using mingw_stdthread::timed_mutex;
-using mingw_stdthread::once_flag;
-using mingw_stdthread::call_once;
+  using mingw_stdthread::recursive_mutex;
+  using mingw_stdthread::mutex;
+  using mingw_stdthread::recursive_timed_mutex;
+  using mingw_stdthread::timed_mutex;
+  using mingw_stdthread::once_flag;
+  using mingw_stdthread::call_once;
 #elif !defined(MINGW_STDTHREAD_REDUNDANCY_WARNING)  //  Skip repetition
-#define MINGW_STDTHREAD_REDUNDANCY_WARNING
-#pragma message "This version of MinGW seems to include a win32 port of\
- pthreads, and probably already has C++11 std threading classes implemented,\
- based on pthreads. These classes, found in namespace std, are not overridden\
- by the mingw-std-thread library. If you would still like to use this\
- implementation (as it is more lightweight), use the classes provided in\
- namespace mingw_stdthread."
+  #define MINGW_STDTHREAD_REDUNDANCY_WARNING
+  #ifdef __MINGW32__
+    #pragma message "This version of MinGW seems to include a win32 port of\
+     pthreads, and probably already has C++11 std threading classes implemented,\
+     based on pthreads."
+  #else
+    #pragma message "You are using a non-MinGW compiler that probably already has std threading\
+     classes"
+  #endif
+  #pragma message "These classes, found in namespace std, are not overridden\
+   by the mingw-std-thread library. If you would still like to use this\
+   implementation (as it is more lightweight), the classes are provided in\
+   namespace mingw_stdthread."
 #endif
 }
 #endif // WIN32STDMUTEX_H

--- a/mingw.thread.h
+++ b/mingw.thread.h
@@ -24,9 +24,6 @@
 #error A C++11 compiler is required!
 #endif
 
-//  Use the standard classes for std::, if available.
-#include <thread>
-
 #include <windows.h>
 #include <functional>
 #include <memory>
@@ -226,22 +223,27 @@ namespace std
 //  was none. Direct specification (std::), however, would be unaffected.
 //    Take the safe option, and include only in the presence of MinGW's win32
 //  implementation.
-#if defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS)
+#if defined(__MINGW32__) && !defined(_GLIBCXX_HAS_GTHREADS)
+
 using mingw_stdthread::thread;
-//    Remove ambiguity immediately, to avoid problems arising from the above.
-//using std::thread;
 namespace this_thread
 {
-using namespace mingw_stdthread::this_thread;
+    using namespace mingw_stdthread::this_thread;
 }
 #elif !defined(MINGW_STDTHREAD_REDUNDANCY_WARNING)  //  Skip repetition
-#define MINGW_STDTHREAD_REDUNDANCY_WARNING
-#pragma message "This version of MinGW seems to include a win32 port of\
- pthreads, and probably already has C++11 std threading classes implemented,\
- based on pthreads. These classes, found in namespace std, are not overridden\
- by the mingw-std-thread library. If you would still like to use this\
- implementation (as it is more lightweight), use the classes provided in\
- namespace mingw_stdthread."
+  #define MINGW_STDTHREAD_REDUNDANCY_WARNING
+  #ifdef __MINGW32__
+    #pragma message "This version of MinGW seems to include a win32 port of\
+     pthreads, and probably already has C++11 std threading classes implemented,\
+     based on pthreads."
+  #else
+    #pragma message "You are using a non-MinGW compiler that probably already has std threading\
+     classes"
+  #endif
+  #pragma message "These classes, found in namespace std, are not overridden\
+   by the mingw-std-thread library. If you would still like to use this\
+   implementation (as it is more lightweight), the classes are provided in\
+   namespace mingw_stdthread."
 #endif
 
 //    Specialize hash for this implementation's thread::id, even if the


### PR DESCRIPTION
 - Implemented the handling of the case where the compiler is not MinGW. Currently, the code will wrongly display a warning that the compiler is MinGW and has std::threads based on pthread, which would be completley wrong under MSVC.
 - Removed the silent inclusion of the standard threading headers - leave that to the user. Otherwise, on non-mingw platforms, if the user is to avoid `#ifdef __MINGW32__`, they would have to include the standard threading header via this (platform-specific) library, and would get a warning that they are not using a mingw compiler and std threading classes probably already exist.