### PR TITLE
Implement and use invoke for thread and call_once

### DIFF
--- a/mingw.mutex.h
+++ b/mingw.mutex.h
@@ -39,7 +39,9 @@
 #include <mutex> //need for call_once()
 #include <assert.h>
 
-#include "mingw.thread.h" //  Need for yield in spinlock
+//  Need for yield in spinlock and the implementation of invoke
+#include "mingw.thread.h"
+
 
 #ifndef EPROTO
     #define EPROTO 134
@@ -473,13 +475,7 @@ void call_once(once_flag& flag, Callable&& func, Args&&... args)
     lock_guard<mutex> lock(flag.mMutex);
     if (flag.mHasRun.load(std::memory_order_acquire))
         return;
-//    std::invoke seems to be not defined at least in some cases. Use it if it's
-//  available, or skip it if it's not.
-#if (__cplusplus >= 201703L)
-    std::invoke(std::forward<Callable>(func),std::forward<Args>(args)...);
-#else
-    func(std::forward<Args>(args)...);
-#endif
+    detail::invoke(std::forward<Callable>(func),std::forward<Args>(args)...);
     flag.mHasRun.store(true, std::memory_order_release);
 }
 } //  Namespace mingw_stdthread

--- a/mingw.thread.h
+++ b/mingw.thread.h
@@ -36,6 +36,7 @@
 #include <ostream>
 #include <process.h>
 #include <ostream>
+#include <type_traits>
 
 //instead of INVALID_HANDLE_VALUE _beginthreadex returns 0
 #define _STD_THREAD_INVALID_HANDLE 0
@@ -43,6 +44,89 @@ namespace mingw_stdthread
 {
 namespace detail
 {
+//  For compatibility, implement std::invoke for C++11 and C++14
+#if __cplusplus < 201703L
+  template<bool PMemFunc, bool PMemData>
+  struct Invoker
+  {
+    template<class F, class... Args>
+    inline static typename std::result_of<F(Args...)>::type invoke (F&& f, Args&&... args)
+    {
+      return std::forward<F>(f)(std::forward<Args>(args)...);
+    }
+  };
+  template<bool>
+  struct InvokerHelper;
+
+  template<>
+  struct InvokerHelper<false>
+  {
+    template<class T1>
+    inline static auto get (T1&& t1) -> decltype(*std::forward<T1>(t1))
+    {
+      return *std::forward<T1>(t1);
+    }
+
+    template<class T1>
+    inline static auto get (const std::reference_wrapper<T1>& t1) -> decltype(t1.get())
+    {
+      return t1.get();
+    }
+  };
+
+  template<>
+  struct InvokerHelper<true>
+  {
+    template<class T1>
+    inline static auto get (T1&& t1) -> decltype(std::forward<T1>(t1))
+    {
+      return std::forward<T1>(t1);
+    }
+  };
+
+  template<>
+  struct Invoker<true, false>
+  {
+    template<class T, class F, class T1, class... Args>
+    inline static auto invoke (F T::* f, T1&& t1, Args&&... args) ->\
+      decltype((InvokerHelper<std::is_base_of<T,typename std::decay<T1>::type>::value>::get(std::forward<T1>(t1)).*f)(std::forward<Args>(args)...))
+    {
+      return (InvokerHelper<std::is_base_of<T,typename std::decay<T1>::type>::value>::get(std::forward<T1>(t1)).*f)(std::forward<Args>(args)...);
+    }
+  };
+
+  template<>
+  struct Invoker<false, true>
+  {
+    template<class T, class F, class T1, class... Args>
+    inline static auto invoke (F T::* f, T1&& t1, Args&&... args) ->\
+      decltype(InvokerHelper<std::is_base_of<T,typename std::decay<T1>::type>::value>::get(t1).*f)
+    {
+      return InvokerHelper<std::is_base_of<T,typename std::decay<T1>::type>::value>::get(t1).*f;
+    }
+  };
+
+  template<class F, class... Args>
+  struct InvokeResult
+  {
+    typedef Invoker<std::is_member_function_pointer<typename std::remove_reference<F>::type>::value,
+                    std::is_member_object_pointer<typename std::remove_reference<F>::type>::value &&
+                    (sizeof...(Args) == 1)> invoker;
+    inline static auto invoke (F&& f, Args&&... args) -> decltype(invoker::invoke(std::forward<F>(f), std::forward<Args>(args)...))
+    {
+      return invoker::invoke(std::forward<F>(f), std::forward<Args>(args)...);
+    };
+  };
+
+  template<class F, class...Args>
+  auto invoke (F&& f, Args&&... args) -> decltype(InvokeResult<F, Args...>::invoke(std::forward<F>(f), std::forward<Args>(args)...))
+  {
+    return InvokeResult<F, Args...>::invoke(std::forward<F>(f), std::forward<Args>(args)...);
+  }
+#else
+    using std::invoke;
+#endif
+
     template<int...>
     struct IntSeq {};
 
@@ -64,7 +148,7 @@ namespace detail
       template <int... S>
       void callFunc(detail::IntSeq<S...>)
       {
-          mFunc(std::get<S>(std::forward<Tuple>(mArgs)) ...);
+          detail::invoke(std::forward<Func>(mFunc), std::get<S>(std::forward<Tuple>(mArgs)) ...);
       }
     };
 


### PR DESCRIPTION
Resolves standard-compliance issues for `thread` and `call_once`. Specifically, these are to behave as if they use `std::invoke`, a C++17 feature. This pull request
- Implements `invoke` for C++11 and C++14.
- Uses `invoke` for calls in `thread` and `call_once`.
