### PR TITLE
Tentative support for Windows Phone 8

### DIFF
--- a/mingw.condition_variable.h
+++ b/mingw.condition_variable.h
@@ -44,6 +44,10 @@ using std::cv_status;
 #endif
 namespace xp
 {
+//    Include the XP-compatible condition_variable classes only if actually
+//  compiling for XP. The XP-compatible classes are slower than the newer
+//  versions, and depend on features not compatible with Windows Phone 8.
+#if (WINVER < _WIN32_WINNT_VISTA)
 class condition_variable_any
 {
 protected:
@@ -231,6 +235,7 @@ public:
         return base::wait_until(lock, abs_time, pred);
     }
 };
+#endif  //  Compiling for XP
 } //  Namespace mingw_stdthread::xp
 
 #if (WINVER >= _WIN32_WINNT_VISTA)

--- a/mingw.thread.h
+++ b/mingw.thread.h
@@ -263,7 +263,7 @@ public:
     static unsigned int _hardware_concurrency_helper() noexcept
     {
         SYSTEM_INFO sysinfo;
-        ::GetSystemInfo(&sysinfo);
+        ::GetNativeSystemInfo(&sysinfo);
         return sysinfo.dwNumberOfProcessors;
     }
 


### PR DESCRIPTION
As mentioned in #39 , the library is currently incompatible with Windows Phone 8. Two changes are necessary. Specifically:
- GetSystemInfo in mingw.thread.h must be replaced with GetNativeSystemInfo. This can affect behavior of 32-bit software emulated on 64-bit Windows by WOW64, but this should be harmless (generating too few or too many threads for the emulator may reduce performance, but this should still give a good match for the hardware).
- Semaphores needed to be removed. Specifically, the XP-compatible `condition_variable` classes needed to be removed or replaced. I have opted to remove them except when compiling for XP. Because there is already a native `condition_variable` implementation for Vista and higher, this change should be undetectable to users unless they are explicitly referring to the `mingw_stdthread::xp` namespace.

Other headers appear not to need any changes.