### PR TITLE
Improve performance for Vista, fix bug with deferred initialization

### DIFF
--- a/mingw.condition_variable.h
+++ b/mingw.condition_variable.h
@@ -378,12 +378,15 @@ protected:
     typedef condition_variable base;
     typedef windows7::shared_mutex native_shared_mutex;
 
-    mutex internal_mutex_;
+//    When available, the SRW-based mutexes should be faster than the
+//  CriticalSection-based mutexes. Only try_lock will be unavailable in Vista,
+//  and try_lock is not used by condition_variable_any.
+    windows7::mutex internal_mutex_;
 
     template<class L>
     bool wait_impl (L & lock, DWORD time)
     {
-        unique_lock<mutex> internal_lock(internal_mutex_);
+        unique_lock<decltype(internal_mutex_)> internal_lock(internal_mutex_);
         lock.unlock();
         bool success = base::wait_impl(internal_lock, time);
         lock.lock();

--- a/mingw.mutex.h
+++ b/mingw.mutex.h
@@ -278,7 +278,10 @@ public:
                 break;
             }
             if (state == 1)
+            {
                 this_thread::yield();
+                state = mState.load(std::memory_order_acquire);
+            }
         }
 #ifndef STDMUTEX_NO_RECURSION_CHECKS
         DWORD self = mOwnerThread.checkOwnerBeforeLock();


### PR DESCRIPTION
When compiling for Windows XP, many workarounds are required to ensure standard-compliance. In particular, the `xp::mutex` class both uses a CriticalSection object and deferred initialization.

For Windows Vista, the more lightweight SRW Locks can be used internally for both `once_flag` and `condition_variable_any`. This pull request switches the internal mutexes used when compiling for Windows Vista to be as modern as is available.

This pull request also fixes a potentially unterminated loop that could occur if an instance of `xp::mutex` is locked in one thread while another thread is in the process of initializing it.