### PR TITLE
Enhanced debugging

### DIFF
--- a/mingw.condition_variable.h
+++ b/mingw.condition_variable.h
@@ -259,7 +259,7 @@ protected:
     template<typename MTX>
     inline static void after_wait (MTX * pmutex)
     {
-        pmutex->mOwnerThread.setOwnerAfterLock();
+        pmutex->mOwnerThread.setOwnerAfterLock(GetCurrentThreadId());
     }
 #else
     inline static void before_wait (void *) { }

--- a/mingw.condition_variable.h
+++ b/mingw.condition_variable.h
@@ -259,7 +259,7 @@ protected:
     template<typename MTX>
     inline static void after_wait (MTX * pmutex)
     {
-        pmutex->mOwnerThread.setOwnerAfterLock(GetCurrentThreadId());
+        pmutex->mOwnerThread.setOwnerAfterLock();
     }
 #else
     inline static void before_wait (void *) { }

--- a/mingw.condition_variable.h
+++ b/mingw.condition_variable.h
@@ -28,7 +28,7 @@
 #include <condition_variable>
 
 #include <atomic>
-#include <assert.h>
+#include <cassert>
 #include <chrono>
 #include <system_error>
 #include <windows.h>
@@ -103,7 +103,10 @@ protected:
 //The notify_all() must handle this grafecully
 //
         else
-            throw std::system_error(EPROTO, std::generic_category());
+        {
+            using namespace std;
+            throw system_error(make_error_code(errc::protocol_error));
+        }
     }
 public:
     template <class M>
@@ -407,7 +410,7 @@ protected:
 //  until Windows 7 that a full implementation is natively possible. The class
 //  itself is defined, with missing features, at the Vista feature level.
     static_assert(CONDITION_VARIABLE_LOCKMODE_SHARED != 0, "The flag \
-CONDITION_VARIABLE_LOCKMODE_SHARED is not defined as expected. The flag for \
+CONDITION_VARIABLE_LOCKMODE_SHARED is not defined as expected. The value for \
 exclusive mode is unknown (not specified by Microsoft Dev Center), but assumed \
 to be 0. There is a conflict with CONDITION_VARIABLE_LOCKMODE_SHARED.");
 //#if (WINVER >= _WIN32_WINNT_VISTA)

--- a/mingw.condition_variable.h
+++ b/mingw.condition_variable.h
@@ -250,7 +250,7 @@ class condition_variable
 protected:
     CONDITION_VARIABLE cvariable_;
 
-#ifndef STDMUTEX_NO_RECURSION_CHECKS
+#if STDMUTEX_RECURSION_CHECKS
     template<typename MTX>
     inline static void before_wait (MTX * pmutex)
     {

--- a/mingw.condition_variable.h
+++ b/mingw.condition_variable.h
@@ -172,8 +172,12 @@ public:
       Predicate pred)
     {
         while (!pred())
+        {
             if (wait_until(lock, abs_time) == cv_status::timeout)
+            {
                 return pred();
+            }
+        }
         return true;
     }
 };

--- a/mingw.mutex.h
+++ b/mingw.mutex.h
@@ -94,7 +94,7 @@ protected:
 public:
     using typename base::native_handle_type;
     using base::native_handle;
-    _NonRecursive() noexcept :base(), mOwnerThread(0) {}
+    constexpr _NonRecursive() noexcept :base(), mOwnerThread(0) {}
     _NonRecursive (const _NonRecursive<B>&) = delete;
     _NonRecursive& operator= (const _NonRecursive<B>&) = delete;
     void lock()
@@ -284,7 +284,7 @@ class once_flag
     template<class Callable, class... Args>
     friend void call_once(once_flag& once, Callable&& f, Args&&... args);
 public:
-    once_flag(): mHasRun(false) {}
+    constexpr once_flag() noexcept: mHasRun(false) {}
 
 };
 

--- a/mingw.mutex.h
+++ b/mingw.mutex.h
@@ -95,16 +95,12 @@ public:
     }
 };
 
-
-thread_local DWORD mThisThread = 0;
-
 struct _OwnerThread
 {
 //    If this is to be read before locking, then the owner-thread variable must
 //  be atomic to prevent a torn read from spuriously causing errors.
     std::atomic<DWORD> mOwnerThread;
-
-    constexpr _OwnerThread () noexcept : mOwnerThread(0) { }
+    constexpr _OwnerThread () noexcept : mOwnerThread(0) {}
     static void on_deadlock (void)
     {
         using namespace std;
@@ -113,26 +109,62 @@ struct _OwnerThread
         fflush(stderr);
         throw system_error(make_error_code(errc::resource_deadlock_would_occur));
     }
-    void checkOwnerBeforeLock() const
+    DWORD checkOwnerBeforeLock() const
     {
-        if (mThisThread == 0)
-            mThisThread = GetCurrentThreadId();
-        if (mOwnerThread.load(std::memory_order_relaxed) == mThisThread)
+        DWORD self = GetCurrentThreadId();
+        if (mOwnerThread.load(std::memory_order_relaxed) == self)
             on_deadlock();
+        return self;
     }
-    void setOwnerAfterLock()
+    void setOwnerAfterLock(DWORD id)
     {
-        mOwnerThread.store(mThisThread, std::memory_order_relaxed);
+        mOwnerThread.store(id, std::memory_order_relaxed);
     }
     void checkSetOwnerBeforeUnlock()
     {
-//        DWORD self = GetCurrentThreadId();
-        if ((mOwnerThread.load(std::memory_order_relaxed) != mThisThread) ||
-            (mThisThread == 0))
+        DWORD self = GetCurrentThreadId();
+        if (mOwnerThread.load(std::memory_order_relaxed) != self)
             on_deadlock();
         mOwnerThread.store(0, std::memory_order_relaxed);
     }
 };
+
+/*template <class B>
+class _NonRecursive: protected B
+{
+protected:
+#ifndef STDMUTEX_NO_RECURSION_CHECKS
+//    Allow condition variable to unlock the native handle directly.
+    friend class vista::condition_variable;
+#endif
+    typedef B base;
+    _OwnerThread mOwnerThread;
+public:
+    using typename base::native_handle_type;
+    using base::native_handle;
+    constexpr _NonRecursive() noexcept :base(), mOwnerThread() {}
+    _NonRecursive (const _NonRecursive<B>&) = delete;
+    _NonRecursive& operator= (const _NonRecursive<B>&) = delete;
+    void lock()
+    {
+        DWORD self = mOwnerThread.checkOwnerBeforeLock();
+        base::lock();
+        mOwnerThread.setOwnerAfterLock(self);
+    }
+    void unlock()
+    {
+        mOwnerThread.checkSetOwnerBeforeUnlock();
+        base::unlock();
+    }
+    bool try_lock()
+    {
+        DWORD self = mOwnerThread.checkOwnerBeforeLock();
+        bool ret = base::try_lock();
+        if (ret)
+            mOwnerThread.setOwnerAfterLock(self);
+        return ret;
+    }
+};*/
 
 //    Though the Slim Reader-Writer (SRW) locks used here are not complete until
 //  Windows 7, implementing partial functionality in Vista will simplify the
@@ -160,11 +192,11 @@ public:
     void lock (void)
     {
 #ifndef STDMUTEX_NO_RECURSION_CHECKS
-        mOwnerThread.checkOwnerBeforeLock();
+        DWORD self = mOwnerThread.checkOwnerBeforeLock();
 #endif
         AcquireSRWLockExclusive(&mHandle);
 #ifndef STDMUTEX_NO_RECURSION_CHECKS
-        mOwnerThread.setOwnerAfterLock();
+        mOwnerThread.setOwnerAfterLock(self);
 #endif
     }
     void unlock (void)
@@ -179,12 +211,12 @@ public:
     bool try_lock (void)
     {
 #ifndef STDMUTEX_NO_RECURSION_CHECKS
-        mOwnerThread.checkOwnerBeforeLock();
+        DWORD self = mOwnerThread.checkOwnerBeforeLock();
 #endif
         BOOL ret = TryAcquireSRWLockExclusive(&mHandle);
 #ifndef STDMUTEX_NO_RECURSION_CHECKS
         if (ret)
-            mOwnerThread.setOwnerAfterLock();
+            mOwnerThread.setOwnerAfterLock(self);
 #endif
         return ret;
     }
@@ -198,6 +230,12 @@ public:
 #endif  //  Compiling for Vista
 namespace xp
 {
+/*
+#ifndef STDMUTEX_NO_RECURSION_CHECKS
+    typedef _NonRecursive<recursive_mutex> mutex;
+#else
+    typedef recursive_mutex mutex;
+#endif*/
 class mutex
 {
     CRITICAL_SECTION mHandle;
@@ -237,11 +275,11 @@ public:
             }
         }
 #ifndef STDMUTEX_NO_RECURSION_CHECKS
-        mOwnerThread.checkOwnerBeforeLock();
+        DWORD self = mOwnerThread.checkOwnerBeforeLock();
 #endif
         EnterCriticalSection(&mHandle);
 #ifndef STDMUTEX_NO_RECURSION_CHECKS
-        mOwnerThread.setOwnerAfterLock();
+        mOwnerThread.setOwnerAfterLock(self);
 #endif
     }
     void unlock (void)
@@ -263,12 +301,12 @@ public:
         if (state == 1)
             return false;
 #ifndef STDMUTEX_NO_RECURSION_CHECKS
-        mOwnerThread.checkOwnerBeforeLock();
+        DWORD self = mOwnerThread.checkOwnerBeforeLock();
 #endif
         BOOL ret = TryEnterCriticalSection(&mHandle);
 #ifndef STDMUTEX_NO_RECURSION_CHECKS
         if (ret)
-            mOwnerThread.setOwnerAfterLock();
+            mOwnerThread.setOwnerAfterLock(self);
 #endif
         return ret;
     }
@@ -362,9 +400,9 @@ public:
     timed_mutex& operator=(const timed_mutex&) = delete;
     void lock()
     {
-        mOwnerThread.checkOwnerBeforeLock();
+        DWORD self = mOwnerThread.checkOwnerBeforeLock();
         recursive_timed_mutex::lock();
-        mOwnerThread.setOwnerAfterLock();
+        mOwnerThread.setOwnerAfterLock(self);
     }
     void unlock()
     {
@@ -374,10 +412,10 @@ public:
     template <class Rep, class Period>
     bool try_lock_for(const std::chrono::duration<Rep,Period>& dur)
     {
-        mOwnerThread.checkOwnerBeforeLock();
+        DWORD self = mOwnerThread.checkOwnerBeforeLock();
         bool ret = recursive_timed_mutex::try_lock_for(dur);
         if (ret)
-            mOwnerThread.setOwnerAfterLock();
+            mOwnerThread.setOwnerAfterLock(self);
         return ret;
     }
     template <class Clock, class Duration>

--- a/mingw.mutex.h
+++ b/mingw.mutex.h
@@ -129,43 +129,6 @@ struct _OwnerThread
     }
 };
 
-/*template <class B>
-class _NonRecursive: protected B
-{
-protected:
-#ifndef STDMUTEX_NO_RECURSION_CHECKS
-//    Allow condition variable to unlock the native handle directly.
-    friend class vista::condition_variable;
-#endif
-    typedef B base;
-    _OwnerThread mOwnerThread;
-public:
-    using typename base::native_handle_type;
-    using base::native_handle;
-    constexpr _NonRecursive() noexcept :base(), mOwnerThread() {}
-    _NonRecursive (const _NonRecursive<B>&) = delete;
-    _NonRecursive& operator= (const _NonRecursive<B>&) = delete;
-    void lock()
-    {
-        DWORD self = mOwnerThread.checkOwnerBeforeLock();
-        base::lock();
-        mOwnerThread.setOwnerAfterLock(self);
-    }
-    void unlock()
-    {
-        mOwnerThread.checkSetOwnerBeforeUnlock();
-        base::unlock();
-    }
-    bool try_lock()
-    {
-        DWORD self = mOwnerThread.checkOwnerBeforeLock();
-        bool ret = base::try_lock();
-        if (ret)
-            mOwnerThread.setOwnerAfterLock(self);
-        return ret;
-    }
-};*/
-
 //    Though the Slim Reader-Writer (SRW) locks used here are not complete until
 //  Windows 7, implementing partial functionality in Vista will simplify the
 //  interaction with condition variables.
@@ -230,12 +193,6 @@ public:
 #endif  //  Compiling for Vista
 namespace xp
 {
-/*
-#ifndef STDMUTEX_NO_RECURSION_CHECKS
-    typedef _NonRecursive<recursive_mutex> mutex;
-#else
-    typedef recursive_mutex mutex;
-#endif*/
 class mutex
 {
     CRITICAL_SECTION mHandle;

--- a/mingw.shared_mutex.h
+++ b/mingw.shared_mutex.h
@@ -143,7 +143,7 @@ public:
     void lock (void)
     {
 #ifndef STDMUTEX_NO_RECURSION_CHECKS
-        DWORD self = mOwnerThread.checkOwnerBeforeLock();
+        mOwnerThread.checkOwnerBeforeLock();
 #endif
         using namespace std;
 //  Might be able to use relaxed memory order...
@@ -158,14 +158,14 @@ public:
             current = mCounter.load(std::memory_order_acquire);
         }
 #ifndef STDMUTEX_NO_RECURSION_CHECKS
-        mOwnerThread.setOwnerAfterLock(self);
+        mOwnerThread.setOwnerAfterLock();
 #endif
     }
 
     bool try_lock (void)
     {
 #ifndef STDMUTEX_NO_RECURSION_CHECKS
-        DWORD self = mOwnerThread.checkOwnerBeforeLock();
+        mOwnerThread.checkOwnerBeforeLock();
 #endif
         counter_type expected = 0;
         bool ret = mCounter.compare_exchange_strong(expected, kWriteBit,
@@ -173,7 +173,7 @@ public:
                                                     std::memory_order_relaxed);
 #ifndef STDMUTEX_NO_RECURSION_CHECKS
         if (ret)
-            mOwnerThread.setOwnerAfterLock(self);
+            mOwnerThread.setOwnerAfterLock();
 #endif
         return ret;
     }
@@ -253,7 +253,7 @@ using windows7::shared_mutex;
 using portable::shared_mutex;
 #endif
 
-class shared_timed_mutex : protected shared_mutex
+class shared_timed_mutex : shared_mutex
 {
     typedef shared_mutex Base;
 public:

--- a/mingw.shared_mutex.h
+++ b/mingw.shared_mutex.h
@@ -31,7 +31,7 @@
 #error A C++11 compiler is required!
 #endif
 
-#include <assert.h>
+#include <cassert>
 
 //    Use MinGW's shared_lock class template, if it's available. Requires C++14.
 //  If unavailable (eg. because this library is being used in C++11), then an

--- a/mingw.shared_mutex.h
+++ b/mingw.shared_mutex.h
@@ -38,10 +38,9 @@
 //  implementation of shared_lock is provided by this header.
 #if (__cplusplus >= 201402L)
 #include <shared_mutex>
-#else
+#endif
 //  For defer_lock_t, adopt_lock_t, and try_to_lock_t
 #include "mingw.mutex.h"
-#endif
 
 //  For descriptive errors.
 #include <system_error>

--- a/mingw.shared_mutex.h
+++ b/mingw.shared_mutex.h
@@ -180,7 +180,6 @@ public:
     void unlock (void)
     {
 #if STDMUTEX_RECURSION_CHECKS
-#error TEST!
         mOwnerThread.checkSetOwnerBeforeUnlock();
 #endif
         using namespace std;

--- a/mingw.shared_mutex.h
+++ b/mingw.shared_mutex.h
@@ -252,7 +252,7 @@ using windows7::shared_mutex;
 using portable::shared_mutex;
 #endif
 
-class shared_timed_mutex : protected shared_mutex
+class shared_timed_mutex : shared_mutex
 {
     typedef shared_mutex Base;
 public:

--- a/mingw.shared_mutex.h
+++ b/mingw.shared_mutex.h
@@ -142,7 +142,7 @@ public:
     void lock (void)
     {
 #ifndef STDMUTEX_NO_RECURSION_CHECKS
-        mOwnerThread.checkOwnerBeforeLock();
+        DWORD self = mOwnerThread.checkOwnerBeforeLock();
 #endif
         using namespace std;
 //  Might be able to use relaxed memory order...
@@ -157,14 +157,14 @@ public:
             current = mCounter.load(std::memory_order_acquire);
         }
 #ifndef STDMUTEX_NO_RECURSION_CHECKS
-        mOwnerThread.setOwnerAfterLock();
+        mOwnerThread.setOwnerAfterLock(self);
 #endif
     }
 
     bool try_lock (void)
     {
 #ifndef STDMUTEX_NO_RECURSION_CHECKS
-        mOwnerThread.checkOwnerBeforeLock();
+        DWORD self = mOwnerThread.checkOwnerBeforeLock();
 #endif
         counter_type expected = 0;
         bool ret = mCounter.compare_exchange_strong(expected, kWriteBit,
@@ -172,7 +172,7 @@ public:
                                                     std::memory_order_relaxed);
 #ifndef STDMUTEX_NO_RECURSION_CHECKS
         if (ret)
-            mOwnerThread.setOwnerAfterLock();
+            mOwnerThread.setOwnerAfterLock(self);
 #endif
         return ret;
     }
@@ -252,7 +252,7 @@ using windows7::shared_mutex;
 using portable::shared_mutex;
 #endif
 
-class shared_timed_mutex : shared_mutex
+class shared_timed_mutex : protected shared_mutex
 {
     typedef shared_mutex Base;
 public:

--- a/mingw.shared_mutex.h
+++ b/mingw.shared_mutex.h
@@ -69,7 +69,7 @@ class shared_mutex
     std::atomic<counter_type> mCounter;
     static constexpr counter_type kWriteBit = 1 << (sizeof(counter_type) * CHAR_BIT - 1);
 
-#ifndef STDMUTEX_NO_RECURSION_CHECKS
+#if STDMUTEX_RECURSION_CHECKS
 //  Runtime checker for verifying owner threads. Note: Exclusive mode only.
     _OwnerThread mOwnerThread;
 #endif
@@ -78,7 +78,7 @@ public:
 
     shared_mutex ()
         : mCounter(0)
-#ifndef STDMUTEX_NO_RECURSION_CHECKS
+#if STDMUTEX_RECURSION_CHECKS
         , mOwnerThread()
 #endif
     {
@@ -141,7 +141,7 @@ public:
 //  Behavior is undefined if a lock was previously acquired.
     void lock (void)
     {
-#ifndef STDMUTEX_NO_RECURSION_CHECKS
+#if STDMUTEX_RECURSION_CHECKS
         DWORD self = mOwnerThread.checkOwnerBeforeLock();
 #endif
         using namespace std;
@@ -156,21 +156,21 @@ public:
             this_thread::yield();
             current = mCounter.load(std::memory_order_acquire);
         }
-#ifndef STDMUTEX_NO_RECURSION_CHECKS
+#if STDMUTEX_RECURSION_CHECKS
         mOwnerThread.setOwnerAfterLock(self);
 #endif
     }
 
     bool try_lock (void)
     {
-#ifndef STDMUTEX_NO_RECURSION_CHECKS
+#if STDMUTEX_RECURSION_CHECKS
         DWORD self = mOwnerThread.checkOwnerBeforeLock();
 #endif
         counter_type expected = 0;
         bool ret = mCounter.compare_exchange_strong(expected, kWriteBit,
                                                     std::memory_order_acquire,
                                                     std::memory_order_relaxed);
-#ifndef STDMUTEX_NO_RECURSION_CHECKS
+#if STDMUTEX_RECURSION_CHECKS
         if (ret)
             mOwnerThread.setOwnerAfterLock(self);
 #endif
@@ -179,7 +179,8 @@ public:
 
     void unlock (void)
     {
-#ifndef STDMUTEX_NO_RECURSION_CHECKS
+#if STDMUTEX_RECURSION_CHECKS
+#error TEST!
         mOwnerThread.checkSetOwnerBeforeUnlock();
 #endif
         using namespace std;

--- a/mingw.thread.h
+++ b/mingw.thread.h
@@ -38,6 +38,10 @@
 #include <ostream>
 #include <type_traits>
 
+#ifndef NDEBUG
+#include <cstdio>
+#endif
+
 //instead of INVALID_HANDLE_VALUE _beginthreadex returns 0
 #define _STD_THREAD_INVALID_HANDLE 0
 namespace mingw_stdthread
@@ -246,13 +250,25 @@ public:
     ~thread()
     {
         if (joinable())
+        {
+#ifndef NDEBUG
+            std::printf("Error: Must join() or detach() a thread before \
+destroying it.\n");
+#endif
             std::terminate();
+        }
     }
     thread& operator=(const thread&) = delete;
     thread& operator=(thread&& other) noexcept
     {
         if (joinable())
-          std::terminate();
+        {
+#ifndef NDEBUG
+            std::printf("Error: Must join() or detach() a thread before \
+moving another thread to it.\n");
+#endif
+            std::terminate();
+        }
         swap(std::forward<thread>(other));
         return *this;
     }

--- a/mingw.thread.h
+++ b/mingw.thread.h
@@ -67,10 +67,14 @@ public:
 
         template<class _CharT, class _Traits>
         friend std::basic_ostream<_CharT, _Traits>&
-        operator<<(std::basic_ostream<_CharT, _Traits>& __out, id __id) {
-            if (__id == id()) {
-                return __out << "thread::id of a non-executing thread";
-            } else {
+        operator<<(std::basic_ostream<_CharT, _Traits>& __out, id __id)
+        {
+            if (__id.mId == 0)
+            {
+                return __out << "(invalid std::thread::id)";
+            }
+            else
+            {
                 return __out << __id.mId;
             }
         }

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -3,7 +3,7 @@
 #include "../mingw.condition_variable.h"
 #include "../mingw.shared_mutex.h"
 #include <atomic>
-#include <assert.h>
+#include <cassert>
 #include <string>
 #include <iostream>
 #include <windows.h>

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -12,6 +12,12 @@ bool cond = false;
 std::mutex m;
 std::condition_variable cv;
 #define LOG(fmtString,...) printf(fmtString "\n", ##__VA_ARGS__); fflush(stdout)
+void test_call_once(int a, const char* str)
+{
+    LOG("test_call_once called with a=%d, str=%s", a, str);
+    this_thread::sleep_for(std::chrono::milliseconds(5000));
+}
+
 int main()
 {
     std::thread t([](bool a, const char* b, int c)mutable
@@ -54,7 +60,10 @@ int main()
     {
         LOG("EXCEPTION in main thread: %s", e.what());
     }
-
+    once_flag of;
+    call_once(of, test_call_once, 1, "test");
+    call_once(of, test_call_once, 1, "ERROR! Should not be called second time");
+    LOG("Test complete");
     return 0;
 }
 


### PR DESCRIPTION
Improves debugging features of the library. Specifically,
- Adds recursion checking for all exclusive-mode operations in `shared_mutex`.
- Adds an explanatory message (instead of just calling `std::terminate()`) if `NDEBUG` is undefined and a thread is moved to or destroyed while in a joinable state.
- Makes certain cases of inheritance private to better conform to the standard.