### PR TITLE
Core features from <future>

### DIFF
--- a/mingw.future.h
+++ b/mingw.future.h
@@ -935,7 +935,7 @@ struct StorageHelper
   static void store_deferred (FutureState<Ret> * state_ptr, Func && func, Args&&... args)
   {
     try {
-      state_ptr->set_value(std::forward<Func>(func)(std::forward<Args>(args)...));
+      state_ptr->set_value(mingw_stdthread::detail::invoke(std::forward<Func>(func), std::forward<Args>(args)...));
     } catch (...) {
       state_ptr->set_exception(std::current_exception());
     }
@@ -958,7 +958,8 @@ struct StorageHelper<Ref&>
   {
     try {
       typedef typename std::remove_cv<Ref>::type Ref_non_cv;
-      Ref & rf = std::forward<Func>(func)(std::forward<Args>(args)...);
+      //Ref & rf = std::forward<Func>(func)(std::forward<Args>(args)...);
+      Ref & rf = mingw_stdthread::detail::invoke(std::forward<Func>(func), std::forward<Args>(args)...);
       state_ptr->set_value(const_cast<Ref_non_cv *>(std::addressof(rf)));
     } catch (...) {
       state_ptr->set_exception(std::current_exception());
@@ -981,7 +982,8 @@ struct StorageHelper<void>
   static void store_deferred (FutureState<Empty> * state_ptr, Func && func, Args&&... args)
   {
     try {
-      std::forward<Func>(func)(std::forward<Args>(args)...);
+      //std::forward<Func>(func)(std::forward<Args>(args)...);
+      mingw_stdthread::detail::invoke(std::forward<Func>(func), std::forward<Args>(args)...);
       state_ptr->set_value(Empty{});
     } catch (...) {
       state_ptr->set_exception(std::current_exception());

--- a/mingw.future.h
+++ b/mingw.future.h
@@ -1,0 +1,1038 @@
+/// \file mingw.future.h
+/// \brief Standard-compliant C++ futures for MinGW
+///
+/// (c) 2018 by Nathaniel J. McClatchey, San Jose, California
+/// \author Nathaniel J. McClatchey, PhD
+///
+/// \copyright Simplified (2-clause) BSD License.
+///
+/// \note This file may become part of the mingw-w64 runtime package. If/when
+/// this happens, the appropriate license will be added, i.e. this code will
+/// become dual-licensed, and the current BSD 2-clause license will stay.
+/// \note Target Windows version is determined by WINVER, which is determined in
+/// <windows.h> from _WIN32_WINNT, which can itself be set by the user.
+
+#ifndef MINGW_FUTURE_H_
+#define MINGW_FUTURE_H_
+
+#if !defined(__cplusplus) || (__cplusplus < 201103L)
+#error The MinGW STD Threads library requires a compiler supporting C++11.
+#endif
+
+#include <future>
+
+#include <cassert>
+#include <vector>
+#include <utility>  //  For std::pair
+#include "mingw.thread.h"
+#include "mingw.mutex.h"
+#include "mingw.condition_variable.h"
+
+//  Note:
+//    std::shared_ptr is the natural choice for this. However, a custom
+//  implementation removes the need to keep a control block separate from the
+//  class itself (no need to support weak pointers).
+
+namespace mingw_stdthread
+{
+using std::future_errc;
+using std::future_error;
+using std::future_status;
+using std::launch;
+using std::future_category;
+
+namespace detail
+{
+struct Empty { };
+
+//    Use a class template to allow instantiation of statics in a header-only
+//  library. Note: Template will only be instantiated once to avoid bloat.
+template<bool>
+struct FutureStatic
+{
+  enum Type : uint_fast8_t
+  {
+    kUndecided = 0x00,
+    kDeferred = 0x05,
+    kValue = 0x02,
+    kException = 0x03,
+    kSetFlag = 0x02,
+    kTypeMask = 0x03,
+    kReadyFlag = 0x04
+  };
+
+  static std::vector<std::pair<mutex, condition_variable> > sync_pool;
+
+  static mutex & get_mutex (void const * ptr)
+  {
+    std::hash<void const *> hash_func;
+    return sync_pool[hash_func(ptr) % sync_pool.size()].first;
+  }
+  static condition_variable & get_condition_variable (void const * ptr)
+  {
+    std::hash<void const *> hash_func;
+    return sync_pool[hash_func(ptr) % sync_pool.size()].second;
+  }
+};
+template<bool b>
+std::vector<std::pair<mutex, condition_variable> > FutureStatic<b>::sync_pool (thread::hardware_concurrency() * 2 + 1);
+
+struct FutureStateBase
+{
+  inline mutex & get_mutex (void) const
+  {
+    return FutureStatic<true>::get_mutex(this);
+  }
+  inline condition_variable & get_condition_variable (void) const
+  {
+    return FutureStatic<true>::get_condition_variable(this);
+  }
+  typedef typename FutureStatic<true>::Type Type;
+//  Destroys this object. Used for allocator-awareness.
+  virtual void deallocate_this (void) noexcept = 0;
+  virtual ~FutureStateBase (void) = default;
+
+  FutureStateBase (FutureStateBase const &) = delete;
+  FutureStateBase & operator= (FutureStateBase const &) = delete;
+
+  FutureStateBase(Type t) noexcept
+    : mReferences(0), mType(t)
+  {
+  }
+
+  void increment_references (void) noexcept
+  {
+    mReferences.fetch_add(1, std::memory_order_relaxed);
+  }
+
+  void decrement_references (void) noexcept
+  {
+    if (mReferences.fetch_sub(1, std::memory_order_acquire) == 0)
+      deallocate_this();
+  }
+
+  std::atomic<size_t> mReferences;
+  std::atomic<uint_fast8_t> mType;
+ /*private:
+  template<class T>
+  friend class FutureState;
+  ~FutureStateBase() noexcept = default;*/
+};
+
+//  Reduce compilation time and improve code re-use.
+struct FutureBase : public FutureStatic<true>
+{
+  typedef FutureStatic<true> Base;
+  FutureStateBase * mState;
+
+  mutex & get_mutex (void) const
+  {
+    return FutureStatic<true>::get_mutex(mState);
+  }
+  condition_variable & get_condition_variable (void) const
+  {
+    return FutureStatic<true>::get_condition_variable(mState);
+  }
+
+  FutureBase (FutureStateBase * ptr) noexcept
+    : mState(ptr)
+  {
+  }
+
+  FutureBase (FutureBase && source) noexcept
+    : mState(source.mState)
+  {
+    source.mState = nullptr;
+  }
+
+  ~FutureBase (void)
+  {
+    release();
+  }
+
+  FutureBase (FutureBase const &) = delete;
+  FutureBase & operator= (FutureBase const &) = delete;
+
+  bool valid (void) const noexcept
+  {
+    return mState != nullptr;
+  }
+
+//    Releases this object's hold on its state. Requires a specification of
+//  which state is being used.
+  inline void release (void) noexcept
+  {
+    if (valid())
+      mState->decrement_references();
+    mState = nullptr;
+  }
+
+  void wait (std::unique_lock<mutex> & lock) const
+  {
+#if !defined(NDEBUG)
+    if (!valid())
+      throw future_error(future_errc::no_state);
+#endif
+//    If there's already a value or exception, don't do any extraneous
+//  synchronization. The `get()` method will do that for us.
+    if (mState->mType.load(std::memory_order_relaxed) & kReadyFlag)
+      return;
+    get_condition_variable().wait(lock, [this](void)->bool {
+      return mState->mType.load(std::memory_order_relaxed) & kReadyFlag;
+    });
+  }
+
+  template<class Rep, class Period>
+  future_status wait_for (std::chrono::duration<Rep,Period> const & dur) const
+  {
+#if !defined(NDEBUG)
+    if (!valid())
+      throw future_error(future_errc::no_state);
+#endif
+    auto current_state = mState->mType.load(std::memory_order_relaxed);
+    if (current_state & kReadyFlag)
+      return (current_state == kDeferred) ? future_status::deferred : future_status::ready;
+    std::unique_lock<mutex> lock { get_mutex() };
+    if (get_condition_variable().wait_for(lock, dur,
+          [this](void)->bool {
+            return mState->mType.load(std::memory_order_relaxed) & kReadyFlag;
+          }))
+      return future_status::ready;
+    else
+      return future_status::timeout;
+  }
+
+  template<class Clock, class Duration>
+  future_status wait_until(const std::chrono::time_point<Clock,Duration>& time) const
+  {
+    return wait_for(time - Clock::now());
+  }
+};
+
+template<class T>
+struct FutureState : public FutureStateBase
+{
+//    The state never needs more than one of these at any one time, so don't
+//  waste space or allocation time.
+  union {
+    struct {} mUndecided;  //  Included to make the active member unambiguous.
+    T mObject;
+    std::exception_ptr mException;
+    std::function<T(void)> mFunction;
+  };
+
+  FutureState (void) noexcept
+    : FutureStateBase(Type::kUndecided), mUndecided()
+  {
+  }
+
+  FutureState (std::function<T(void)> && deferred_function)
+    : FutureStateBase(Type::kDeferred), mFunction(std::move(deferred_function))
+  {
+  }
+
+  void deallocate_this (void) noexcept override
+  {
+    delete this;
+  }
+
+/*  void set_deferred (std::function<T(void)> && func)
+  {
+    assert(type_ = 0x00);
+    new(&function_) std::function<T(void)>(std::move(func));
+    type_.store(0x01, std::memory_order_release);
+  }*/
+  template<class Arg>
+  void set_value (Arg && arg)
+  {
+    assert(!(mType.load(std::memory_order_relaxed) & Type::kSetFlag));
+    new(&mObject) T (std::forward<Arg>(arg));
+    mType.store(Type::kValue | Type::kReadyFlag, std::memory_order_release);
+  }
+  template<class Arg>
+  void set_exception (Arg && arg)
+  {
+    assert(!(mType.load(std::memory_order_relaxed) & Type::kSetFlag));
+    new(&mException) std::exception_ptr (std::forward<Arg>(arg));
+    mType.store(Type::kException | Type::kReadyFlag, std::memory_order_release);
+  }
+//  These overloads set value/exception, but don't make it ready.
+  template<class Arg>
+  void set_value (Arg && arg, bool)
+  {
+    assert(!(mType.load(std::memory_order_relaxed) & Type::kSetFlag));
+    new(&mObject) T (std::forward<Arg>(arg));
+    mType.store(Type::kValue, std::memory_order_release);
+  }
+  template<class Arg>
+  void set_exception (Arg && arg, bool)
+  {
+    assert(!(mType.load(std::memory_order_relaxed) & Type::kSetFlag));
+    new(&mException) std::exception_ptr (std::forward<Arg>(arg));
+    mType.store(Type::kException, std::memory_order_release);
+  }
+ //private:
+  ~FutureState (void)
+  {
+    switch (mType.load(std::memory_order_acquire) & Type::kTypeMask)
+    {
+    case Type::kDeferred & Type::kTypeMask:
+      mFunction.~function();
+      break;
+    case Type::kValue:
+      mObject.~T();
+      break;
+    case Type::kException:
+      mException.~exception_ptr();
+      break;
+    default:;
+    }
+  }
+};
+
+template<class T, class Alloc>
+struct FutureStateAllocated : public FutureState<T>
+{
+  typedef typename std::allocator_traits<Alloc>::void_pointer void_pointer;
+  void_pointer mThis;
+  Alloc mAllocator;
+
+  FutureStateAllocated (Alloc const & alloc, void_pointer const & vptr) noexcept
+    : FutureState<T>(), mThis(vptr), mAllocator(alloc)
+  {
+  }
+
+  FutureStateAllocated (FutureStateAllocated<T,Alloc> const &) = delete;
+  FutureStateAllocated<T,Alloc> & operator= (FutureStateAllocated<T,Alloc> const &) = delete;
+
+  void deallocate_this (void) noexcept override
+  {
+    typedef typename std::allocator_traits<Alloc>::template rebind_traits<FutureStateAllocated<T, Alloc> > allocator_traits;
+    typename allocator_traits::allocator_type alloc(std::move(mAllocator));
+    typedef typename allocator_traits::pointer pointer;
+    pointer ptr(static_cast<pointer>(mThis));
+    allocator_traits::destroy(alloc, this);
+    allocator_traits::deallocate(alloc, ptr, 1);
+  }
+ /*private:
+  ~FutureStateAllocated (void) = default;*/
+};
+}
+
+#if (defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS))
+}
+namespace std {
+#else
+template<class T>
+class future;
+template<class T>
+class shared_future;
+template<class T>
+class promise;
+#endif
+
+template<class T>
+class future : mingw_stdthread::detail::FutureBase
+{
+  typedef mingw_stdthread::detail::FutureState<T> state_type;
+  future (state_type * ptr) noexcept
+    : FutureBase(ptr)
+  {
+  }
+
+  friend class shared_future<T>;
+  friend class promise<T>;
+  /*template<class Function, class ... Args>
+  friend future<__async_result_of<Function, Args...> > async (Function &&, Args&&...);*/
+
+  template<class U>
+  friend class future;
+
+  template<class _Fn, class ... _Args>
+  friend future<__async_result_of<_Fn, _Args...>> async (std::launch, _Fn &&, _Args&&...);
+ public:
+  using FutureBase::valid;
+  using FutureBase::wait_for;
+  using FutureBase::wait_until;
+
+  future (void) noexcept
+    : FutureBase(nullptr)
+  {
+  }
+  future<T> & operator= (future<T> && source) noexcept
+  {
+//  Check for this atypical behavior rather than creating a nonsensical state.
+    if (this != &source)
+    {
+      release();
+      mState = source.mState;
+      source.mState = nullptr;
+    }
+    return *this;
+  }
+  future (future<T> && source) noexcept
+    : FutureBase(std::move(source))
+  {
+  }
+
+  ~future (void) = default;
+
+  future (future<T> const &) = delete;
+  future<T> & operator= (future<T> const &) = delete;
+
+  T const & get (void) const
+  {
+    wait();
+    if (mState->mType.load(std::memory_order_acquire) == (kValue | kReadyFlag))
+      return static_cast<state_type *>(mState)->mObject;
+    else
+    {
+      assert(mState->mType.load(std::memory_order_relaxed) == (kException | kReadyFlag));
+      std::rethrow_exception(static_cast<state_type *>(mState)->mException);
+    }
+  }
+
+  shared_future<T> share (void) noexcept
+  {
+    return std::move(shared_future<T>(std::move(*this)));
+  }
+
+  void wait (void) const
+  {
+    std::unique_lock<mingw_stdthread::mutex> lock { get_mutex() };
+    FutureBase::wait(lock);
+    if (mState->mType.load(std::memory_order_acquire) == kDeferred)
+    {
+      state_type * ptr = static_cast<state_type *>(mState);
+      decltype(ptr->mFunction) func = std::move(ptr->mFunction);
+      ptr->mFunction.~function();
+      try {
+        ptr->set_value(func());
+      } catch (...) {
+        ptr->set_exception(std::current_exception());
+      }
+    }
+  }
+};
+
+template<class T>
+class shared_future : future<T>
+{
+  typedef typename future<T>::state_type state_type;
+ public:
+  using future<T>::get;
+  using future<T>::wait;
+  using future<T>::wait_for;
+  using future<T>::wait_until;
+  using future<T>::valid;
+
+  shared_future (void) noexcept : future<T>()
+  {
+  }
+
+  shared_future (shared_future<T> && source) noexcept
+    : future<T>(std::move(source))
+  {
+  }
+
+  shared_future<T> & operator= (shared_future<T> && source) noexcept
+  {
+    return future<T>::operator=(std::move(source));
+  }
+
+  shared_future (shared_future<T> const & source) noexcept(__cplusplus >= 201703L)
+    : future<T>(source.mState)
+  {
+    future<T>::mState->increment_references();
+  }
+
+  shared_future<T> & operator= (shared_future<T> const & source) noexcept(__cplusplus >= 201703L)
+  {
+    if (future<T>::mState == source.mState)
+      return *this;
+    future<T>::release();
+    future<T>::mState = source.mState;
+    future<T>::mState->increment_references();
+    return *this;
+  }
+
+  shared_future (future<T> && source) noexcept
+    : future<T>(std::move(source))
+  {
+  }
+
+  shared_future<T> & operator= (future<T> && source) noexcept
+  {
+    future<T>::operator=(std::move(source));
+    return *this;
+  }
+
+  ~shared_future (void) = default;
+};
+
+template<class T>
+class promise : mingw_stdthread::detail::FutureBase
+{
+  bool mRetrieved;
+  typedef mingw_stdthread::detail::FutureState<T> state_type;
+  void check_before_set (void) const
+  {
+    if (!valid())
+      throw future_error(future_errc::no_state);
+    if (mState->mType.load(std::memory_order_relaxed) & kSetFlag)
+      throw future_error(future_errc::promise_already_satisfied);
+  }
+
+  void check_abandon (void)
+  {
+    if (valid() && !(mState->mType.load(std::memory_order_relaxed) & kSetFlag))
+    {
+      try {
+        throw future_error(future_errc::broken_promise);
+      } catch (...) {
+        set_exception(std::current_exception());
+      }
+    }
+  }
+/// \bug Might throw more exceptions than specified by the standard...
+//  Need OS support for this...
+  void make_ready_at_thread_exit (void)
+  {
+//  Need to turn the pseudohandle from GetCurrentThread() into a true handle...
+    HANDLE thread_handle;
+    BOOL success = DuplicateHandle(GetCurrentProcess(),
+                                   GetCurrentThread(),
+                                   GetCurrentProcess(),
+                                   &thread_handle,
+                                   0, //  Access doesn't matter. Will be duplicated.
+                                   FALSE, //  No need for this to be inherited.
+                                   DUPLICATE_SAME_ACCESS | DUPLICATE_CLOSE_SOURCE);
+    if (!success)
+      throw std::runtime_error("MinGW STD Threads library failed to make a promise ready after thread exit.");
+
+    mState->increment_references();
+    bool handle_handled = false;
+    try {
+      state_type * ptr = static_cast<state_type *>(mState);
+      mingw_stdthread::thread watcher_thread ([ptr, thread_handle, &handle_handled](void)
+        {
+          {
+            std::lock_guard<mingw_stdthread::mutex> guard (ptr->get_mutex());
+            handle_handled = true;
+          }
+          ptr->get_condition_variable().notify_all();
+//  Wait for the original thread to die.
+          WaitForSingleObject(thread_handle, INFINITE);
+          CloseHandle(thread_handle);
+
+          {
+            std::lock_guard<mingw_stdthread::mutex> guard (ptr->get_mutex());
+            ptr->mType.fetch_or(kReadyFlag, std::memory_order_relaxed);
+          }
+          ptr->get_condition_variable().notify_all();
+
+          ptr->decrement_references();
+        });
+      {
+        std::unique_lock<mingw_stdthread::mutex> guard (ptr->get_mutex());
+        ptr->get_condition_variable().wait(guard, [&handle_handled](void)->bool
+          {
+            return handle_handled;
+          });
+      }
+      watcher_thread.detach();
+    }
+    catch (...)
+    {
+//    Because the original promise is still alive, this can't be the decrement
+//  destroys it.
+      mState->decrement_references();
+      if (!handle_handled)
+        CloseHandle(thread_handle);
+    }
+  }
+
+  template<class U>
+  future<U> make_future (void)
+  {
+    if (!valid())
+      throw future_error(future_errc::no_state);
+    if (mRetrieved)
+      throw future_error(future_errc::future_already_retrieved);
+    mState->increment_references();
+    mRetrieved = true;
+    return future<U>(static_cast<state_type *>(mState));
+  }
+
+  template<class U>
+  friend class promise;
+ public:
+//    Create a promise with an empty state, with the reference counter set to
+//  indicate that the state is only held by this promise (i.e. not by any
+//  futures).
+  promise (void)
+    : FutureBase(new state_type ()), mRetrieved(false)
+  {
+  }
+
+  template<typename Alloc>
+  promise (std::allocator_arg_t, Alloc const & alloc)
+    : FutureBase(nullptr), mRetrieved(false)
+  {
+    typedef mingw_stdthread::detail::FutureStateAllocated<T,Alloc> State;
+    typedef typename std::allocator_traits<Alloc>::template rebind_traits<State> Traits;
+    typename Traits::allocator_type rebound_alloc(alloc);
+    typename Traits::pointer ptr = Traits::allocate(rebound_alloc, 1);
+    typename Traits::void_pointer vptr = ptr;
+    State * sptr = std::addressof(*ptr);
+    Traits::construct(rebound_alloc, sptr, std::move(rebound_alloc), vptr);
+    mState = static_cast<state_type *>(sptr);
+  }
+
+  promise (promise<T> && source) noexcept
+    : FutureBase(std::move(source)), mRetrieved(source.mRetrieved)
+  {
+  }
+
+  ~promise (void)
+  {
+    check_abandon();
+  }
+
+  promise<T> & operator= (promise<T> && source) noexcept
+  {
+    if (this == &source)
+      return *this;
+    check_abandon();
+    release();
+    mState = source.mState;
+    mRetrieved = source.mRetrieved;
+    source.mState = nullptr;
+    return *this;
+  }
+
+  void swap (promise<T> & other) noexcept
+  {
+    std::swap(mState, other.mState);
+    std::swap(mRetrieved, other.mRetrieved);
+  }
+
+  promise (promise<T> const &) = delete;
+  promise<T> & operator= (promise<T> const &) = delete;
+
+  future<T> get_future (void)
+  {
+    return make_future<T>();
+  }
+
+  void set_value (T const & value)
+  {
+    {
+      std::unique_lock<mingw_stdthread::mutex> lock { get_mutex() };
+      check_before_set();
+//    std::unique_lock<mutex> lock {detail::FutureStatic<true>::get_mutex(state_ptr_.get()); };
+      static_cast<state_type *>(mState)->set_value(value);
+    }
+    get_condition_variable().notify_all();
+  }
+
+  void set_value (T && value)
+  {
+    {
+      std::unique_lock<mingw_stdthread::mutex> lock { get_mutex() };
+      check_before_set();
+      static_cast<state_type *>(mState)->set_value(std::move(value));
+    }
+    get_condition_variable().notify_all();
+  }
+
+  void set_value_at_thread_exit (T const & value)
+  {
+    {
+      std::unique_lock<mingw_stdthread::mutex> lock { get_mutex() };
+      check_before_set();
+//    std::unique_lock<mutex> lock {detail::FutureStatic<true>::get_mutex(state_ptr_.get()); };
+      static_cast<state_type *>(mState)->set_value(value, false);
+    }
+    make_ready_at_thread_exit();
+  }
+
+  void set_value_at_thread_exit (T && value)
+  {
+    {
+      std::unique_lock<mingw_stdthread::mutex> lock { get_mutex() };
+      check_before_set();
+      static_cast<state_type *>(mState)->set_value(std::move(value), false);
+    }
+    make_ready_at_thread_exit();
+  }
+
+  void set_exception (std::exception_ptr eptr)
+  {
+    {
+      std::unique_lock<mingw_stdthread::mutex> lock { get_mutex() };
+      check_before_set();
+      static_cast<state_type *>(mState)->set_exception(eptr);
+    }
+    get_condition_variable().notify_all();
+  }
+
+  void set_exception_at_thread_exit (std::exception_ptr eptr)
+  {
+    {
+      std::unique_lock<mingw_stdthread::mutex> lock { get_mutex() };
+      check_before_set();
+      static_cast<state_type *>(mState)->set_exception(eptr, false);
+    }
+    make_ready_at_thread_exit();
+  }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+//                           Reference Specialization                         //
+////////////////////////////////////////////////////////////////////////////////
+
+template<class T>
+class future<T&> : future<T*>
+{
+  template<class U>
+  friend class shared_future;
+  template<class U>
+  friend class promise;
+
+  future (typename future<T*>::state_type * state)
+    : future<T*>(state)
+  {
+  }
+
+ public:
+  using future<T*>::valid;
+  using future<T*>::wait_for;
+  using future<T*>::wait_until;
+  using future<T*>::wait;
+
+  future (void) noexcept = default;
+
+  T& get (void) const
+  {
+    return *future<T*>::get();
+  }
+
+  shared_future<T&> share (void) noexcept;
+};
+
+template<class T>
+class shared_future<T&> : shared_future<T*>
+{
+ public:
+  using shared_future<T*>::wait;
+  using shared_future<T*>::wait_for;
+  using shared_future<T*>::wait_until;
+  using shared_future<T*>::valid;
+
+  T& get (void) const
+  {
+    return *shared_future<T*>::get();
+  }
+
+  shared_future (void) noexcept = default;
+
+  shared_future (shared_future<T&> && source) noexcept = default;
+
+  shared_future<T&> & operator= (shared_future<T&> && source) noexcept = default;
+
+  shared_future (shared_future<T&> const & source) noexcept(__cplusplus >= 201703L) = default;
+
+  shared_future<T&> & operator= (shared_future<T&> const & source) noexcept(__cplusplus >= 201703L) = default;
+
+  shared_future (future<T&> && source) noexcept
+    : shared_future<T*>(std::move(source))
+  {
+  }
+
+  shared_future<T&> & operator= (future<T&> && source) noexcept
+  {
+    shared_future<T*>::operator=(std::move(source));
+    return *this;
+  }
+
+  ~shared_future (void) = default;
+};
+
+template<class T>
+shared_future<T&> future<T&>::share (void) noexcept
+{
+  return std::move(shared_future<T&>(std::move(*this)));
+  //return future<Empty>::share();
+}
+
+template<class T>
+class promise<T&> : private promise<T*>
+{
+ public:
+  using promise<T*>::set_exception;
+  using promise<T*>::set_exception_at_thread_exit;
+
+  promise (void) = default;
+  template<typename Alloc>
+  promise (std::allocator_arg_t arg, Alloc const & alloc)
+    : promise<T*>(arg, alloc)
+  {
+  }
+
+  inline void set_value (T & value)
+  {
+    promise<T*>::set_value(&value);
+  }
+
+  inline void set_value_at_thread_exit (T & value)
+  {
+    promise<T*>::set_value_at_thread_exit(&value);
+  }
+
+  inline future<T&> get_future (void)
+  {
+    return promise<T*>::template make_future<T&>();
+  }
+
+  void swap (promise<T&> & other) noexcept
+  {
+    promise<T*>::swap(other);
+  }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+//                              Void Specialization                           //
+////////////////////////////////////////////////////////////////////////////////
+
+template<>
+class future<void> : future<mingw_stdthread::detail::Empty>
+{
+  typedef mingw_stdthread::detail::Empty Empty;
+  template<class U>
+  friend class shared_future;
+  template<class U>
+  friend class promise;
+
+  future(future<Empty>::state_type * state)
+    : future<Empty>(state)
+  {
+  }
+
+ public:
+  using future<Empty>::valid;
+  using future<Empty>::wait_for;
+  using future<Empty>::wait_until;
+  using future<Empty>::wait;
+
+  future (void) noexcept = default;
+
+  void get (void) const
+  {
+    future<Empty>::get();
+  }
+
+  shared_future<void> share (void) noexcept;
+};
+
+template<>
+class shared_future<void> : shared_future<mingw_stdthread::detail::Empty>
+{
+  typedef mingw_stdthread::detail::Empty Empty;
+ public:
+  using shared_future<Empty>::wait;
+  using shared_future<Empty>::wait_for;
+  using shared_future<Empty>::wait_until;
+  using shared_future<Empty>::valid;
+
+  void get (void) const
+  {
+    shared_future<Empty>::get();
+  }
+
+  shared_future (void) noexcept = default;
+
+  shared_future (shared_future<void> && source) noexcept = default;
+
+  shared_future<void> & operator= (shared_future<void> && source) noexcept = default;
+
+  shared_future (shared_future<void> const & source) noexcept(__cplusplus >= 201703L) = default;
+
+  shared_future<void> & operator= (shared_future<void> const & source) noexcept(__cplusplus >= 201703L) = default;
+
+  shared_future (future<void> && source) noexcept
+    : shared_future<Empty>(std::move(source))
+  {
+  }
+
+  shared_future<void> & operator= (future<void> && source) noexcept
+  {
+    shared_future<Empty>::operator=(std::move(source));
+    return *this;
+  }
+
+  ~shared_future (void) = default;
+};
+
+shared_future<void> future<void>::share (void) noexcept
+{
+  return std::move(shared_future<void>(std::move(*this)));
+  //return future<Empty>::share();
+}
+
+template<>
+class promise<void> : private promise<mingw_stdthread::detail::Empty>
+{
+  typedef mingw_stdthread::detail::Empty Empty;
+ public:
+  using promise<Empty>::set_exception;
+  using promise<Empty>::set_exception_at_thread_exit;
+
+  promise (void) = default;
+  template<typename Alloc>
+  promise (std::allocator_arg_t arg, Alloc const & alloc)
+    : promise<Empty>(arg, alloc)
+  {
+  }
+
+  inline void set_value (void)
+  {
+    promise<Empty>::set_value(Empty());
+  }
+
+  inline void set_value_at_thread_exit (void)
+  {
+    promise<Empty>::set_value_at_thread_exit(Empty());
+  }
+
+  inline future<void> get_future (void)
+  {
+    return promise<Empty>::template make_future<void>();
+  }
+
+  void swap (promise<void> & other) noexcept
+  {
+    promise<Empty>::swap(other);
+  }
+};
+
+
+
+template<class T>
+void swap(promise<T> & lhs, promise<T> & rhs) noexcept
+{
+  lhs.swap(rhs);
+}
+
+template<class T, class Alloc>
+struct uses_allocator<promise<T>, Alloc> : std::true_type
+{
+};
+
+/*}
+namespace mingw_stdthread
+{
+namespace detail
+{
+template<typename T>
+void invoke_and_store(std::promise<T>
+  try {
+    prom2.set_value(mingw_stdthread::detail::invoke(f2, args2...));
+  } catch (...)
+  {
+    prom2.set_exception(std::current_exception());
+  }
+}
+}
+namespace std
+{*/
+
+
+//    Unfortunately, MinGW's <future> locks us into a particular (non-standard)
+//  signature for async.
+template< class Function, class... Args>
+/*#if (__cplusplus < 201703L)
+std::future<std::result_of<std::decay<Function>::type(std::decay<Args>::type...)>::type>
+#else
+#if (__cplusplus > 201703L)
+[[nodiscard]]
+#endif
+std::future<std::invoke_result_t<std::decay_t<Function>, std::decay_t<Args>...>>
+#endif*/
+#if (__cplusplus > 201703L)
+[[nodiscard]]
+#endif
+std::future<__async_result_of<Function, Args...> >
+  async(Function&& f, Args&&... args)
+{
+  return async(launch::async | launch::deferred, std::forward<Function>(f), std::forward<Args>(args)...);
+}
+template< class Function, class... Args >
+/*#if (__cplusplus < 201703L)
+std::future<std::result_of<std::decay<Function>::type(std::decay<Args>::type...)>::type>
+#else
+#if (__cplusplus > 201703L)
+[[nodiscard]]
+#endif
+std::future<std::invoke_result_t<std::decay_t<Function>, std::decay_t<Args>...> >
+#endif*/
+#if (__cplusplus > 201703L)
+[[nodiscard]]
+#endif
+std::future<__async_result_of<Function, Args...> >
+  async(std::launch policy, Function&& f, Args&&... args)
+{
+#if (__cplusplus < 201703L)
+  //typedef std::result_of<std::decay<Function>::type(std::decay<Args>::type...)>::type result_type;
+  typedef __async_result_of<Function, Args...> result_type;
+#else
+  typedef std::invoke_result_t<std::decay_t<Function>, std::decay_t<Args>...> result_type;
+#endif
+  typedef future<result_type> future_type;
+  typedef typename future_type::state_type state_type;
+  if ((policy & std::launch::async) == std::launch::async)
+  {
+    promise<result_type> prom;
+    future<result_type> fut = prom.get_future();
+    mingw_stdthread::thread t ([](promise<result_type> prom2, typename std::decay<Function>::type f2, typename std::decay<Args>::type... args2)
+      {
+        try {
+          prom2.set_value(mingw_stdthread::detail::invoke(f2, args2...));
+        } catch (...)
+        {
+          prom2.set_exception(std::current_exception());
+        }
+      }, std::move(prom), std::forward<Function>(f), std::forward<Args>(args)...);
+    t.detach();
+    return fut;
+  }
+  else
+    return future<result_type>(new state_type(std::function<result_type(void)>(std::bind(std::forward<Function>(f), std::forward<Args>(args)...))));
+}
+
+#if (defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS))
+} //  Namespace std
+namespace mingw_stdthread
+{
+using std::future;
+using std::shared_future;
+using std::promise;
+using std::async;
+#else
+} //  Namespace mingw_stdthread
+namespace std
+{
+template<class T>
+void swap(mingw_stdthread::promise<T> & lhs, mingw_stdthread::promise<T> & rhs) noexcept
+{
+  lhs.swap(rhs);
+}
+
+template<class T, class Alloc>
+struct uses_allocator<mingw_stdthread::promise<T>, Alloc> : std::true_type
+{
+};
+#endif
+} //  Namespace
+
+#endif // MINGW_FUTURE_H_

--- a/mingw.mutex.h
+++ b/mingw.mutex.h
@@ -150,11 +150,14 @@ class mutex
 #endif
 public:
     typedef PSRWLOCK native_handle_type;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
     constexpr mutex () noexcept : mHandle(SRWLOCK_INIT)
 #if STDMUTEX_RECURSION_CHECKS
         , mOwnerThread()
 #endif
     { }
+#pragma GCC diagnostic pop
     mutex (const mutex&) = delete;
     mutex & operator= (const mutex&) = delete;
     void lock (void)

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -40,7 +40,6 @@ struct TestMove
     }
 };
 
-
 template<class T>
 void test_future_set_value (promise<T> & promise)
 {
@@ -100,7 +99,7 @@ struct CustomAllocator
 template<class T>
 void test_future ()
 {
-  static_assert(is_move_constructible<promise<T> >::value,
+  /*static_assert(is_move_constructible<promise<T> >::value,
                 "std::promise must be move-constructible.");
   static_assert(is_move_assignable<promise<T> >::value,
                 "std::promise must be move-assignable.");
@@ -192,32 +191,39 @@ void test_future ()
     LOG("WARNING: %s","Got a value where there should be an exception!");
   } catch (std::future_error & e) {
     LOG("\tReceived a future_error (\"%s\") as expected.", e.what());
-  }
+  }*/
 
-  /*LOG("\t%s", "Deferring a function...");
+  LOG("\t%s", "Deferring a function...");
   auto async_deferred = async(launch::deferred, [] (void) -> T
     {
       std::hash<std::thread::id> hasher;
       LOG("\t\tDeferred function called on thread %zu", hasher(std::this_thread::get_id()));
-      return T();
+      if (!is_void<T>::value)
+        return T(test_int);
     });
   LOG("\t%s", "Calling a function asynchronously...");
   auto async_async = async(launch::async, [] (void) -> T
     {
       std::hash<std::thread::id> hasher;
       LOG("\t\tAsynchronous function called on thread %zu", hasher(std::this_thread::get_id()));
-      return T();
+      if (!is_void<T>::value)
+        return T(test_int);
     });
   LOG("\t%s", "Letting the implementation decide...");
   auto async_either = async([] (thread::id other_id) -> T
     {
       std::hash<thread::id> hasher;
       LOG("\t\tFunction called on thread %zu. Implementation chose %s execution.", hasher(this_thread::get_id()), (this_thread::get_id() == other_id) ? "deferred" : "asynchronous");
-      return T();
+      if (!is_void<T>::value)
+        return T(test_int);
     }, this_thread::get_id());
+
+  LOG("\t%s", "Fetching asynchronous result.");
   async_async.get();
+  LOG("\t%s", "Fetching deferred result.");
   async_deferred.get();
-  async_either.get();*/
+  LOG("\t%s", "Fetching implementation-defined result.");
+  async_either.get();
 }
 
 int main()

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -99,7 +99,7 @@ struct CustomAllocator
 template<class T>
 void test_future ()
 {
-  /*static_assert(is_move_constructible<promise<T> >::value,
+  static_assert(is_move_constructible<promise<T> >::value,
                 "std::promise must be move-constructible.");
   static_assert(is_move_assignable<promise<T> >::value,
                 "std::promise must be move-assignable.");
@@ -191,7 +191,7 @@ void test_future ()
     LOG("WARNING: %s","Got a value where there should be an exception!");
   } catch (std::future_error & e) {
     LOG("\tReceived a future_error (\"%s\") as expected.", e.what());
-  }*/
+  }
 
   LOG("\t%s", "Deferring a function...");
   auto async_deferred = async(launch::deferred, [] (void) -> T

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -173,7 +173,7 @@ void test_future ()
     throw;
   }
   try {
-    future_exception.get();
+    test_future_get_value(future_exception);
     LOG("WARNING: %s","Got a value where there should be an exception!");
   } catch (std::exception & e) {
     LOG("\tReceived an exception (\"%s\") as expected.", e.what());
@@ -181,14 +181,14 @@ void test_future ()
 
   LOG("\t%s", "Waiting for the thread to exit...");
   try {
-    future_late.get();
+    test_future_get_value(future_late);
     LOG("WARNING: %s","Got a value where there should be an exception!");
   } catch (std::exception & e) {
     LOG("\tReceived an exception (\"%s\") as expected.", e.what());
   }
 
   try {
-    future_broken.get();
+    test_future_get_value(future_broken);
     LOG("WARNING: %s","Got a value where there should be an exception!");
   } catch (std::future_error & e) {
     LOG("\tReceived a future_error (\"%s\") as expected.", e.what());
@@ -350,7 +350,10 @@ int main()
       LOG("%s","Testing implementation of <future>...");
       test_future<int>();
       test_future<void>();
-      test_future<int&>();
+      test_future<int &>();
+      test_future<int const &>();
+      test_future<int volatile &>();
+      test_future<int const volatile &>();
       LOG("%s","Testing <future>'s use of allocators. Should allocate, then deallocate.");
       promise<int> allocated_promise (std::allocator_arg, CustomAllocator<unsigned>());
       allocated_promise.set_value(7);

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -219,11 +219,27 @@ void test_future ()
     }, this_thread::get_id());
 
   LOG("\t%s", "Fetching asynchronous result.");
-  async_async.get();
+  test_future_get_value(async_async);
   LOG("\t%s", "Fetching deferred result.");
-  async_deferred.get();
+  test_future_get_value(async_deferred);
   LOG("\t%s", "Fetching implementation-defined result.");
-  async_either.get();
+  test_future_get_value(async_either);
+
+  LOG("\t%s", "Testing async on pointer-to-member-function.");
+  struct Helper
+  {
+    thread::id other_id;
+    T call (void) const
+    {
+      std::hash<thread::id> hasher;
+      LOG("\t\tFunction called on thread %zu. Implementation chose %s execution.", hasher(this_thread::get_id()), (this_thread::get_id() == other_id) ? "deferred" : "asynchronous");
+      if (!is_void<T>::value)
+        return T(test_int);
+    }
+  } test_class { this_thread::get_id() };
+  auto async_member = async(Helper::call, test_class);
+  LOG("\t%s", "Fetching result.");
+  test_future_get_value(async_member);
 }
 
 int main()

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -2,6 +2,7 @@
 #include "../mingw.mutex.h"
 #include "../mingw.condition_variable.h"
 #include "../mingw.shared_mutex.h"
+#include "../mingw.future.h"
 #include <atomic>
 #include <cassert>
 #include <string>
@@ -10,16 +11,21 @@
 
 using namespace std;
 
+int test_int = 42;
+
+//  Pre-declaration to suppress some warnings.
+void test_call_once(int, char const *);
+
 int cond = 0;
 std::mutex m;
 std::shared_mutex sm;
 std::condition_variable cv;
 std::condition_variable_any cv_any;
-#define LOG(fmtString,...) printf(fmtString "\n", ##__VA_ARGS__); fflush(stdout)
+#define LOG(fmtString,...) { printf(fmtString "\n", ##__VA_ARGS__); fflush(stdout); }
 void test_call_once(int a, const char* str)
 {
     LOG("test_call_once called with a=%d, str=%s", a, str);
-    this_thread::sleep_for(std::chrono::milliseconds(5000));
+    this_thread::sleep_for(std::chrono::milliseconds(500));
 }
 
 struct TestMove
@@ -33,6 +39,186 @@ struct TestMove
         assert(false && "TestMove: Object COPIED instead of moved");
     }
 };
+
+
+template<class T>
+void test_future_set_value (promise<T> & promise)
+{
+  promise.set_value(T(test_int));
+}
+
+template<>
+void test_future_set_value (promise<void> & promise)
+{
+  promise.set_value();
+}
+
+template<class T>
+bool test_future_get_value (future<T> & future)
+{
+  return (future.get() == T(test_int));
+}
+
+template<>
+bool test_future_get_value (future<void> & future)
+{
+  future.get();
+  return true;
+}
+
+template<class T>
+struct CustomAllocator
+{
+  CustomAllocator (void) noexcept
+  {
+  }
+
+  template<class U>
+  CustomAllocator (CustomAllocator<U> const &) noexcept
+  {
+  }
+
+  template<class U>
+  CustomAllocator<T> & operator= (CustomAllocator<U> const &) noexcept
+  {
+    return *this;
+  }
+
+  typedef T value_type;
+  T * allocate (size_t n)
+  {
+    LOG("Used custom allocator to allocate %zu object(s).", n);
+    return static_cast<T*>(std::malloc(n * sizeof(T)));
+  }
+  void deallocate (T * ptr, size_t n)
+  {
+    LOG("Used custom allocator to deallocate %zu object(s).", n);
+    std::free(ptr);
+  }
+};
+
+template<class T>
+void test_future ()
+{
+  static_assert(is_move_constructible<promise<T> >::value,
+                "std::promise must be move-constructible.");
+  static_assert(is_move_assignable<promise<T> >::value,
+                "std::promise must be move-assignable.");
+  static_assert(!is_copy_constructible<promise<T> >::value,
+                "std::promise must not be copy-constructible.");
+  static_assert(!is_copy_assignable<promise<T> >::value,
+                "std::promise must not be copy-assignable.");
+
+  static_assert(is_move_constructible<future<T> >::value,
+                "std::future must be move-constructible.");
+  static_assert(is_move_assignable<future<T> >::value,
+                "std::future must be move-assignable.");
+  static_assert(!is_copy_constructible<future<T> >::value,
+                "std::future must not be copy-constructible.");
+  static_assert(!is_copy_assignable<future<T> >::value,
+                "std::future must not be copy-assignable.");
+
+  static_assert(is_move_constructible<shared_future<T> >::value,
+                "std::shared_future must be move-constructible.");
+  static_assert(is_move_assignable<shared_future<T> >::value,
+                "std::shared_future must be move-assignable.");
+  static_assert(is_copy_constructible<shared_future<T> >::value,
+                "std::shared_future must be copy-constructible.");
+  static_assert(is_copy_assignable<shared_future<T> >::value,
+                "std::shared_future must be copy-assignable.");
+
+  LOG("\t%s","Making a few promises, and getting their futures...");
+  promise<T> promise_value, promise_exception, promise_broken, promise_late;
+
+  future<T> future_value = promise_value.get_future();
+  future<T> future_exception = promise_exception.get_future();
+  future<T> future_broken = promise_broken.get_future();
+  future<T> future_late = promise_late.get_future();
+
+  try {
+    future<T> impossible_future = promise_value.get_future();
+    LOG("WARNING: %s","Promise failed to detect that its future was already retrieved.");
+  } catch(...) {
+    LOG("\t%s","Promise successfully prevented redundant future retrieval.");
+  }
+
+  LOG("\t%s","Passing promises to a new thread...");
+  thread t ([](promise<T> p_value, promise<T> p_exception, promise<T>, promise<T> p_late)
+    {
+      this_thread::sleep_for(std::chrono::seconds(1));
+      try {
+        throw std::runtime_error("Thrown during the thread.");
+      } catch (...) {
+        p_late.set_exception_at_thread_exit(std::current_exception());
+      }
+      test_future_set_value(p_value);
+      try {
+        throw std::runtime_error("Things happened as expected.");
+      } catch (...) {
+        p_exception.set_exception(std::current_exception());
+      }
+      this_thread::sleep_for(std::chrono::seconds(2));
+    },
+    std::move(promise_value),
+    std::move(promise_exception),
+    std::move(promise_broken),
+    std::move(promise_late));
+  t.detach();
+
+  try {
+    bool was_expected = test_future_get_value(future_value);
+    LOG("\tReceived %sexpected value.", (was_expected ? "" : "un"));
+  } catch (...) {
+    LOG("WARNING: %s","Exception where there should be none!");
+    throw;
+  }
+  try {
+    future_exception.get();
+    LOG("WARNING: %s","Got a value where there should be an exception!");
+  } catch (std::exception & e) {
+    LOG("\tReceived an exception (\"%s\") as expected.", e.what());
+  }
+
+  LOG("\t%s", "Waiting for the thread to exit...");
+  try {
+    future_late.get();
+    LOG("WARNING: %s","Got a value where there should be an exception!");
+  } catch (std::exception & e) {
+    LOG("\tReceived an exception (\"%s\") as expected.", e.what());
+  }
+
+  try {
+    future_broken.get();
+    LOG("WARNING: %s","Got a value where there should be an exception!");
+  } catch (std::future_error & e) {
+    LOG("\tReceived a future_error (\"%s\") as expected.", e.what());
+  }
+
+  /*LOG("\t%s", "Deferring a function...");
+  auto async_deferred = async(launch::deferred, [] (void) -> T
+    {
+      std::hash<std::thread::id> hasher;
+      LOG("\t\tDeferred function called on thread %zu", hasher(std::this_thread::get_id()));
+      return T();
+    });
+  LOG("\t%s", "Calling a function asynchronously...");
+  auto async_async = async(launch::async, [] (void) -> T
+    {
+      std::hash<std::thread::id> hasher;
+      LOG("\t\tAsynchronous function called on thread %zu", hasher(std::this_thread::get_id()));
+      return T();
+    });
+  LOG("\t%s", "Letting the implementation decide...");
+  auto async_either = async([] (thread::id other_id) -> T
+    {
+      std::hash<thread::id> hasher;
+      LOG("\t\tFunction called on thread %zu. Implementation chose %s execution.", hasher(this_thread::get_id()), (this_thread::get_id() == other_id) ? "deferred" : "asynchronous");
+      return T();
+    }, this_thread::get_id());
+  async_async.get();
+  async_deferred.get();
+  async_either.get();*/
+}
 
 int main()
 {
@@ -90,7 +276,7 @@ int main()
             assert(!strcmp(b, "test message"));
             assert(c == -20);
             auto move2nd = std::move(a); //test move to final destination
-            this_thread::sleep_for(std::chrono::milliseconds(5000));
+            this_thread::sleep_for(std::chrono::milliseconds(1000));
             {
                 lock_guard<mutex> lock(m);
                 cond = 1;
@@ -159,5 +345,16 @@ int main()
     call_once(of, test_call_once, 1, "test");
     call_once(of, test_call_once, 1, "ERROR! Should not be called second time");
     LOG("%s","Test complete");
+
+    {
+      LOG("%s","Testing implementation of <future>...");
+      test_future<int>();
+      test_future<void>();
+      test_future<int&>();
+      LOG("%s","Testing <future>'s use of allocators. Should allocate, then deallocate.");
+      promise<int> allocated_promise (std::allocator_arg, CustomAllocator<unsigned>());
+      allocated_promise.set_value(7);
+    }
+
     return 0;
 }


### PR DESCRIPTION
Implements core features of the C++11 `<future>` header. Specifically, this pull request adds support for 
- `future`
- `shared_future`
- `promise`
- `async`

Some work yet remains before the library can be considered final. Specifically,
- `packaged_task` is not yet implemented.
    + It can be implemented as a wrapper around `std::function` and a `promise`, or the classes internal to `mingw.future.h` can be employed.
- The implementation of `promise<T>::set_value_at_thread_exit` currently uses a second "helper thread" that detects when the original thread exits. This is, of course, inefficient, but I do not yet know another way to ensure that the value is set only after all `thread_local` objects are destroyed. This approach should be replaced later, if doing so is possible.

Though unrelated, the pull request also changes certain protected members of `thread` to be private and replaces a standard-violating macro. Names with an underscore followed by a capital letter are reserved by the standard; the macro's purpose can be accomplished safely by using a static constexpr variable at class scope instead.