### PR TITLE
Fix sleep_for with large/negative values.

### DIFF
--- a/mingw.thread.h
+++ b/mingw.thread.h
@@ -335,9 +335,10 @@ namespace this_thread
             (sleep_duration).count();
         while (ms > 0)
         {
-            Sleep(std::min(ms, static_cast<std::chrono::milliseconds::rep>(
-                std::numeric_limits<DWORD>::max())));
-            ms -= std::numeric_limits<DWORD>::max();
+            DWORD sleepTime = std::min(ms, static_cast<std::chrono::milliseconds::rep>(
+                std::numeric_limits<DWORD>::max() - 1));
+            Sleep(sleepTime);
+            ms -= sleepTime;
         }
     }
     template <class Clock, class Duration>

--- a/mingw.thread.h
+++ b/mingw.thread.h
@@ -336,7 +336,7 @@ namespace this_thread
         while (ms > 0)
         {
             DWORD sleepTime = std::min(ms, static_cast<std::chrono::milliseconds::rep>(
-                std::numeric_limits<DWORD>::max() - 1));
+                INFINITE - 1));
             Sleep(sleepTime);
             ms -= sleepTime;
         }

--- a/mingw.thread.h
+++ b/mingw.thread.h
@@ -37,6 +37,8 @@
 #include <process.h>
 #include <ostream>
 #include <type_traits>
+#include <limits>
+#include <algorithm>
 
 #ifndef NDEBUG
 #include <cstdio>
@@ -328,7 +330,15 @@ namespace this_thread
     template< class Rep, class Period >
     void sleep_for( const std::chrono::duration<Rep,Period>& sleep_duration)
     {
-        Sleep(std::chrono::duration_cast<std::chrono::milliseconds>(sleep_duration).count());
+        std::chrono::milliseconds::rep ms =
+            std::chrono::duration_cast<std::chrono::milliseconds>
+            (sleep_duration).count();
+        while (ms > 0)
+        {
+            Sleep(std::min(ms, static_cast<std::chrono::milliseconds::rep>(
+                std::numeric_limits<DWORD>::max())));
+            ms -= std::numeric_limits<DWORD>::max();
+        }
     }
     template <class Clock, class Duration>
     void sleep_until(const std::chrono::time_point<Clock,Duration>& sleep_time)


### PR DESCRIPTION
Win32 Sleep() takes an unsigned int for milliseconds, so this function would break if you passed it a negative value (calling sleep_until with a time in the past) or a duration longer than 49.7 days.