### PR TITLE
Various bug fixes

### DIFF
--- a/mingw.condition_variable.h
+++ b/mingw.condition_variable.h
@@ -50,7 +50,6 @@ namespace xp
 #if (WINVER < _WIN32_WINNT_VISTA)
 class condition_variable_any
 {
-protected:
     recursive_mutex mMutex;
     std::atomic<int> mNumWaiters;
     HANDLE mSemaphore;
@@ -73,7 +72,7 @@ public:
         CloseHandle(mWakeEvent);
         CloseHandle(mSemaphore);
     }
-protected:
+private:
     template <class M>
     bool wait_impl(M& lock, DWORD timeout)
     {
@@ -197,9 +196,8 @@ public:
         return true;
     }
 };
-class condition_variable: protected condition_variable_any
+class condition_variable: condition_variable_any
 {
-protected:
     typedef condition_variable_any base;
 public:
     using base::native_handle_type;
@@ -246,7 +244,6 @@ namespace vista
 //  If compiling for Vista or higher, use the native condition variable.
 class condition_variable
 {
-protected:
     CONDITION_VARIABLE cvariable_;
 
 #if STDMUTEX_RECURSION_CHECKS
@@ -265,6 +262,7 @@ protected:
     inline static void after_wait (void *) { }
 #endif
 
+protected:
     bool wait_impl (unique_lock<xp::mutex> & lock, DWORD time)
     {
         static_assert(std::is_same<typename xp::mutex::native_handle_type, PCRITICAL_SECTION>::value,
@@ -378,9 +376,8 @@ public:
     }
 };
 
-class condition_variable_any : protected condition_variable
+class condition_variable_any : condition_variable
 {
-protected:
     typedef condition_variable base;
     typedef windows7::shared_mutex native_shared_mutex;
 
@@ -411,7 +408,6 @@ protected:
 CONDITION_VARIABLE_LOCKMODE_SHARED is not defined as expected. The value for \
 exclusive mode is unknown (not specified by Microsoft Dev Center), but assumed \
 to be 0. There is a conflict with CONDITION_VARIABLE_LOCKMODE_SHARED.");
-//#if (WINVER >= _WIN32_WINNT_VISTA)
     bool wait_impl (unique_lock<native_shared_mutex> & lock, DWORD time)
     {
         native_shared_mutex * pmutex = lock.release();
@@ -428,7 +424,6 @@ to be 0. There is a conflict with CONDITION_VARIABLE_LOCKMODE_SHARED.");
         lock = shared_lock<native_shared_mutex>(*pmutex, adopt_lock);
         return success;
     }
-//#endif
 public:
     typedef typename base::native_handle_type native_handle_type;
     using base::native_handle;

--- a/mingw.future.h
+++ b/mingw.future.h
@@ -380,10 +380,7 @@ class future : mingw_stdthread::detail::FutureBase
     }
   }
 
-  shared_future<T> share (void) noexcept
-  {
-    return std::move(shared_future<T>(std::move(*this)));
-  }
+  shared_future<T> share (void) noexcept;
 
   void wait (void) const
   {
@@ -749,12 +746,6 @@ class shared_future<T&> : shared_future<void *>
 };
 
 template<class T>
-shared_future<T&> future<T&>::share (void) noexcept
-{
-  return std::move(shared_future<T&>(std::move(*this)));
-}
-
-template<class T>
 class promise<T&> : private promise<void *>
 {
   typedef promise<void *> Base;
@@ -868,10 +859,10 @@ class shared_future<void> : shared_future<mingw_stdthread::detail::Empty>
   ~shared_future (void) = default;
 };
 
-shared_future<void> future<void>::share (void) noexcept
+template<class T>
+shared_future<T> future<T>::share (void) noexcept
 {
-  return std::move(shared_future<void>(std::move(*this)));
-  //return future<Empty>::share();
+  return shared_future<void>(std::move(*this));
 }
 
 template<>

--- a/mingw.future.h
+++ b/mingw.future.h
@@ -610,9 +610,8 @@ class promise : mingw_stdthread::detail::FutureBase
   void set_value (T const & value)
   {
     {
-      std::unique_lock<mingw_stdthread::mutex> lock { get_mutex() };
+      std::lock_guard<mingw_stdthread::mutex> lock { get_mutex() };
       check_before_set();
-//    std::unique_lock<mutex> lock {detail::FutureStatic<true>::get_mutex(state_ptr_.get()); };
       static_cast<state_type *>(mState)->set_value(value);
     }
     get_condition_variable().notify_all();
@@ -621,7 +620,7 @@ class promise : mingw_stdthread::detail::FutureBase
   void set_value (T && value)
   {
     {
-      std::unique_lock<mingw_stdthread::mutex> lock { get_mutex() };
+      std::lock_guard<mingw_stdthread::mutex> lock { get_mutex() };
       check_before_set();
       static_cast<state_type *>(mState)->set_value(std::move(value));
     }
@@ -631,9 +630,8 @@ class promise : mingw_stdthread::detail::FutureBase
   void set_value_at_thread_exit (T const & value)
   {
     {
-      std::unique_lock<mingw_stdthread::mutex> lock { get_mutex() };
+      std::lock_guard<mingw_stdthread::mutex> lock { get_mutex() };
       check_before_set();
-//    std::unique_lock<mutex> lock {detail::FutureStatic<true>::get_mutex(state_ptr_.get()); };
       static_cast<state_type *>(mState)->set_value(value, false);
     }
     make_ready_at_thread_exit();
@@ -642,7 +640,7 @@ class promise : mingw_stdthread::detail::FutureBase
   void set_value_at_thread_exit (T && value)
   {
     {
-      std::unique_lock<mingw_stdthread::mutex> lock { get_mutex() };
+      std::lock_guard<mingw_stdthread::mutex> lock { get_mutex() };
       check_before_set();
       static_cast<state_type *>(mState)->set_value(std::move(value), false);
     }
@@ -652,7 +650,7 @@ class promise : mingw_stdthread::detail::FutureBase
   void set_exception (std::exception_ptr eptr)
   {
     {
-      std::unique_lock<mingw_stdthread::mutex> lock { get_mutex() };
+      std::lock_guard<mingw_stdthread::mutex> lock { get_mutex() };
       check_before_set();
       static_cast<state_type *>(mState)->set_exception(eptr);
     }
@@ -662,7 +660,7 @@ class promise : mingw_stdthread::detail::FutureBase
   void set_exception_at_thread_exit (std::exception_ptr eptr)
   {
     {
-      std::unique_lock<mingw_stdthread::mutex> lock { get_mutex() };
+      std::lock_guard<mingw_stdthread::mutex> lock { get_mutex() };
       check_before_set();
       static_cast<state_type *>(mState)->set_exception(eptr, false);
     }
@@ -720,16 +718,6 @@ class shared_future<T&> : shared_future<void *>
   {
     return *static_cast<T *>(Base::get());
   }
-
-  /*shared_future (void) noexcept = default;
-
-  shared_future (shared_future<T&> && source) noexcept = default;
-
-  shared_future<T&> & operator= (shared_future<T&> && source) noexcept = default;
-
-  shared_future (shared_future<T&> const & source) noexcept(__cplusplus >= 201703L) = default;
-
-  shared_future<T&> & operator= (shared_future<T&> const & source) noexcept(__cplusplus >= 201703L) = default;*/
 
   shared_future (future<T&> && source) noexcept
     : Base(std::move(source))
@@ -934,9 +922,10 @@ struct StorageHelper
   template<class Func, class ... Args>
   static void store (FutureState<Ret> * state_ptr, Func && func, Args&&... args)
   {
-    std::unique_lock<mingw_stdthread::mutex> lock { state_ptr->get_mutex() };
-    store_deferred(state_ptr, std::forward<Func>(func), std::forward<Args>(args)...);
-    lock.unlock();
+    {
+      std::lock_guard<mingw_stdthread::mutex> lock { state_ptr->get_mutex() };
+      store_deferred(state_ptr, std::forward<Func>(func), std::forward<Args>(args)...);
+    }
     state_ptr->get_condition_variable().notify_all();
   }
 };
@@ -949,7 +938,6 @@ struct StorageHelper<Ref&>
   {
     try {
       typedef typename std::remove_cv<Ref>::type Ref_non_cv;
-      //Ref & rf = std::forward<Func>(func)(std::forward<Args>(args)...);
       Ref & rf = mingw_stdthread::detail::invoke(std::forward<Func>(func), std::forward<Args>(args)...);
       state_ptr->set_value(const_cast<Ref_non_cv *>(std::addressof(rf)));
     } catch (...) {
@@ -959,9 +947,10 @@ struct StorageHelper<Ref&>
   template<class Func, class ... Args>
   static void store (FutureState<void*> * state_ptr, Func && func, Args&&... args)
   {
-    std::unique_lock<mingw_stdthread::mutex> lock { state_ptr->get_mutex() };
-    store_deferred(state_ptr, std::forward<Func>(func), std::forward<Args>(args)...);
-    lock.unlock();
+    {
+      std::lock_guard<mingw_stdthread::mutex> lock { state_ptr->get_mutex() };
+      store_deferred(state_ptr, std::forward<Func>(func), std::forward<Args>(args)...);
+    }
     state_ptr->get_condition_variable().notify_all();
   }
 };
@@ -983,9 +972,10 @@ struct StorageHelper<void>
   template<class Func, class ... Args>
   static void store (FutureState<Empty> * state_ptr, Func && func, Args&&... args)
   {
-    std::unique_lock<mingw_stdthread::mutex> lock { state_ptr->get_mutex() };
-    store_deferred(state_ptr, std::forward<Func>(func), std::forward<Args>(args)...);
-    lock.unlock();
+    {
+      std::lock_guard<mingw_stdthread::mutex> lock { state_ptr->get_mutex() };
+      store_deferred(state_ptr, std::forward<Func>(func), std::forward<Args>(args)...);
+    }
     state_ptr->get_condition_variable().notify_all();
   }
 };
@@ -1075,7 +1065,6 @@ std::future<__async_result_of<Function, Args...> >
     bound->ptr = state_ptr;
   }
   assert(state_ptr != nullptr);
-  //future<result_type> result { state_ptr };
   return future<result_type> { state_ptr };
 }
 

--- a/mingw.mutex.h
+++ b/mingw.mutex.h
@@ -147,17 +147,13 @@ class mutex
 //  Track locking thread for error checking.
 #if STDMUTEX_RECURSION_CHECKS
     friend class vista::condition_variable;
-    _OwnerThread mOwnerThread;
+    _OwnerThread mOwnerThread {};
 #endif
 public:
     typedef PSRWLOCK native_handle_type;
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
-    constexpr mutex () noexcept : mHandle(SRWLOCK_INIT)
-#if STDMUTEX_RECURSION_CHECKS
-        , mOwnerThread()
-#endif
-    { }
+    constexpr mutex () noexcept : mHandle(SRWLOCK_INIT) { }
 #pragma GCC diagnostic pop
     mutex (const mutex&) = delete;
     mutex & operator= (const mutex&) = delete;
@@ -209,15 +205,11 @@ class mutex
 //  Track locking thread for error checking.
 #if STDMUTEX_RECURSION_CHECKS
     friend class vista::condition_variable;
-    _OwnerThread mOwnerThread;
+    _OwnerThread mOwnerThread {};
 #endif
 public:
     typedef PCRITICAL_SECTION native_handle_type;
-    constexpr mutex () noexcept : mHandle(), mState(2)
-#if STDMUTEX_RECURSION_CHECKS
-        , mOwnerThread()
-#endif
-    { }
+    constexpr mutex () noexcept : mHandle(), mState(2) { }
     mutex (const mutex&) = delete;
     mutex & operator= (const mutex&) = delete;
     ~mutex() noexcept
@@ -295,25 +287,21 @@ class recursive_timed_mutex
         assert(ms != INFINITE);
         return (WaitForSingleObject(mHandle, ms) == WAIT_OBJECT_0);
     }
-protected:
     HANDLE mHandle;
+protected:
 //    Track locking thread for error checking of non-recursive timed_mutex. For
 //  standard compliance, this must be defined in same class and at the same
 //  access-control level as every other variable in the timed_mutex.
 #if STDMUTEX_RECURSION_CHECKS
     friend class vista::condition_variable;
-    _OwnerThread mOwnerThread;
+    _OwnerThread mOwnerThread {};
 #endif
 public:
     typedef HANDLE native_handle_type;
     native_handle_type native_handle() const {return mHandle;}
     recursive_timed_mutex(const recursive_timed_mutex&) = delete;
     recursive_timed_mutex& operator=(const recursive_timed_mutex&) = delete;
-    recursive_timed_mutex(): mHandle(CreateMutex(NULL, FALSE, NULL))
-#if STDMUTEX_RECURSION_CHECKS
-        , mOwnerThread()
-#endif
-    {}
+    recursive_timed_mutex(): mHandle(CreateMutex(NULL, FALSE, NULL)) {}
     ~recursive_timed_mutex()
     {
         CloseHandle(mHandle);

--- a/mingw.shared_mutex.h
+++ b/mingw.shared_mutex.h
@@ -119,7 +119,7 @@ public:
 
     bool try_lock_shared (void)
     {
-        counter_type expected = static_cast<counter_type>(mCounter.load(std::memory_order_relaxed) & (~kWriteBit));
+        counter_type expected = mCounter.load(std::memory_order_relaxed) & static_cast<counter_type>(~kWriteBit);
         if (expected + 1 == kWriteBit)
             return false;
         else
@@ -133,7 +133,7 @@ public:
     {
         using namespace std;
 #ifndef NDEBUG
-        if (!(mCounter.fetch_sub(1, memory_order_release) & (~kWriteBit)))
+        if (!(mCounter.fetch_sub(1, memory_order_release) & static_cast<counter_type>(~kWriteBit)))
             throw system_error(make_error_code(errc::operation_not_permitted));
 #else
         mCounter.fetch_sub(1, memory_order_release);

--- a/mingw.shared_mutex.h
+++ b/mingw.shared_mutex.h
@@ -32,16 +32,6 @@
 #endif
 
 #include <cassert>
-
-//    Use MinGW's shared_lock class template, if it's available. Requires C++14.
-//  If unavailable (eg. because this library is being used in C++11), then an
-//  implementation of shared_lock is provided by this header.
-#if (__cplusplus >= 201402L)
-#include <shared_mutex>
-#endif
-//  For defer_lock_t, adopt_lock_t, and try_to_lock_t
-#include "mingw.mutex.h"
-
 //  For descriptive errors.
 #include <system_error>
 //    Implementing a shared_mutex without OS support will require atomic read-
@@ -50,6 +40,15 @@
 //  For timing in shared_lock and shared_timed_mutex.
 #include <chrono>
 
+//    Use MinGW's shared_lock class template, if it's available. Requires C++14.
+//  If unavailable (eg. because this library is being used in C++11), then an
+//  implementation of shared_lock is provided by this header.
+#if (__cplusplus >= 201402L)
+#include <shared_mutex>
+#endif
+
+//  For defer_lock_t, adopt_lock_t, and try_to_lock_t
+#include "mingw.mutex.h"
 //  For this_thread::yield.
 #include "mingw.thread.h"
 
@@ -66,23 +65,17 @@ namespace portable
 class shared_mutex
 {
     typedef uint_fast16_t counter_type;
-    std::atomic<counter_type> mCounter;
+    std::atomic<counter_type> mCounter {0};
     static constexpr counter_type kWriteBit = 1 << (sizeof(counter_type) * CHAR_BIT - 1);
 
 #if STDMUTEX_RECURSION_CHECKS
 //  Runtime checker for verifying owner threads. Note: Exclusive mode only.
-    _OwnerThread mOwnerThread;
+    _OwnerThread mOwnerThread {};
 #endif
 public:
     typedef shared_mutex * native_handle_type;
 
-    shared_mutex ()
-        : mCounter(0)
-#if STDMUTEX_RECURSION_CHECKS
-        , mOwnerThread()
-#endif
-    {
-    }
+    shared_mutex () = default;
 
 //  No form of copying or moving should be allowed.
     shared_mutex (const shared_mutex&) = delete;

--- a/mingw.thread.h
+++ b/mingw.thread.h
@@ -330,13 +330,12 @@ namespace this_thread
     template< class Rep, class Period >
     void sleep_for( const std::chrono::duration<Rep,Period>& sleep_duration)
     {
-        std::chrono::milliseconds::rep ms =
-            std::chrono::duration_cast<std::chrono::milliseconds>
-            (sleep_duration).count();
+        using namespace std::chrono;
+        using rep = milliseconds::rep;
+        rep ms = duration_cast<milliseconds>(sleep_duration).count();
         while (ms > 0)
         {
-            auto sleepTime = std::min(ms, static_cast<std::chrono::milliseconds::rep>(
-                INFINITE - 1));
+            auto sleepTime = std::min(ms, static_cast<rep>(INFINITE - 1));
             Sleep(static_cast<DWORD>(sleepTime));
             ms -= sleepTime;
         }

--- a/mingw.thread.h
+++ b/mingw.thread.h
@@ -132,13 +132,13 @@ namespace detail
     using std::invoke;
 #endif
 
-    template<int...>
+    template<std::size_t...>
     struct IntSeq {};
 
-    template<int N, int... S>
+    template<std::size_t N, std::size_t... S>
     struct GenIntSeq : GenIntSeq<N-1, N-1, S...> { };
 
-    template<int... S>
+    template<std::size_t... S>
     struct GenIntSeq<0, S...> { typedef IntSeq<S...> type; };
 
     // We can't define the Call struct in the function - the standard forbids template methods in that case
@@ -149,7 +149,7 @@ namespace detail
         Func mFunc;
         Tuple mArgs;
 
-        template <int... S>
+        template <std::size_t... S>
         void callFunc(detail::IntSeq<S...>)
         {
             detail::invoke(std::forward<Func>(mFunc), std::get<S>(std::forward<Tuple>(mArgs)) ...);
@@ -160,7 +160,7 @@ namespace detail
 
         void callFunc()
         {
-            callFunc(typename detail::GenIntSeq<static_cast<int>(sizeof...(Args))>::type());
+            callFunc(typename detail::GenIntSeq<sizeof...(Args)>::type());
         }
     };
 
@@ -335,9 +335,9 @@ namespace this_thread
             (sleep_duration).count();
         while (ms > 0)
         {
-            DWORD sleepTime = std::min(ms, static_cast<std::chrono::milliseconds::rep>(
+            auto sleepTime = std::min(ms, static_cast<std::chrono::milliseconds::rep>(
                 INFINITE - 1));
-            Sleep(sleepTime);
+            Sleep(static_cast<DWORD>(sleepTime));
             ms -= sleepTime;
         }
     }


### PR DESCRIPTION
- In `condition_variable`, fix potential for large wait times to act as if an indefinite wait were requested.
- In `mutex`, fix similar problems in `try_lock_for`.
- Fix a bug related to `make_shared` for template specialization `future<void>`.
- Resolve cast warnings in `thread` by altering later code (is now more robust) rather than simply silencing them.