### PR TITLE
Fix bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,41 @@
 mingw-std-threads
 =================
 
-Standard C++11 threading classes implementation, which are currently still missing
-on MinGW GCC.
+Implementation of standard C++11 threading classes, which are currently still missing on MinGW GCC.
 
-Windows compatibility
-=====================
+Target Windows version
+----------------------
 This implementation should work with Windows XP (regardless of service pack), or newer.
-The library automatically detects the version of Windows that is being targeted, and selects an implementation that takes advantage of available Windows features. In MinGW GCC, the target Windows version may optionally be selected by the command-line option `-D _WIN32_WINNT=...`. Use `0x0600` for Windows Vista, or `0x0601` for Windows 7. See ["Modifying `WINVER` and `_WIN32_WINNT`](https://docs.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt).
+The library automatically detects the version of Windows that is being targeted (at compile time), and selects an implementation that takes advantage of available Windows features.
+In MinGW GCC, the target Windows version may optionally be selected by the command-line option `-D _WIN32_WINNT=...`.
+Use `0x0600` for Windows Vista, or `0x0601` for Windows 7.
+See "[Modifying `WINVER` and `_WIN32_WINNT`](https://docs.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt)" for more details.
 
 Usage
-=====
+-----
 
-This is a header-only library. To use, just include the corresponding mingw.xxx.h file, where
-xxx would be the name of the standard header that you would normally include.
-For additional mutex helper classes, such as std::scoped_guard or std::unique_lock, you need to
-include &lt;mutex&gt; before including mingw.mutex.h
+This is a header-only library. To use, just include the corresponding `mingw.xxx.h file`, where `xxx` would be the name of the standard header that you would normally include.
+
+For example, `#include "mingw.thread.h"` replaces `#include <thread>`.
 
 Compatibility
-=============
+-------------
 
-This code has been tested to work with MinGW-w64 5.3.0, but should work with any other MinGW version
-that has the std threading classes missing, has C++11 support for lambda functions, variadic
-templates, and has working mutex helper classes in &lt;mutex&gt;.  
+This code has been tested to work with MinGW-w64 5.3.0, but should work with any other MinGW version that has the `std` threading classes missing, has C++11 support for lambda functions, variadic templates, and has working mutex helper classes in `<mutex>`.
 
 Switching from the win32-pthread based implementation
-=====================================================
-It seems that recent versions of mingw-w64 include a win32 port of pthreads, and have
-the std::thread, std::mutex etc classes implemented and working, based on that compatibility
-layer. This is a somewhat heavier implementation, as it brings a not very thin abstraction layer.
-So you may still want to use this implementation for efficiency purposes. Unfortunately you can't use it
-standalone and independent of the system &lt;mutex&gt; header, as it relies on it for std::unique_lock and other
-non-trivial utility classes. In that case you will need to edit the c++-config.h file of your MinGW setup
-and comment out the definition of _GLIBCXX_HAS_GTHREADS. This will cause the system headers to not define the
-actual thread, mutex, etc classes, but still define the necessary utility classes.
+-----------------------------------------------------
+It seems that recent versions of MinGW-w64 include a Win32 port of pthreads, and have the `std::thread`, `std::mutex`, etc. classes implemented and working based on that compatibility
+layer.
+That is a somewhat heavier implementation, as it relies on an abstraction layer, so you may still want to use this implementation for efficiency purposes.
+Unfortunately you can't use this library standalone and independent of the system `<mutex>` headers, as it relies on those headers for `std::unique_lock` and other non-trivial utility classes.
+In that case you will need to edit the `c++-config.h` file of your MinGW setup and comment out the definition of _GLIBCXX_HAS_GTHREADS.
+This will cause the system headers not to define the actual `thread`, `mutex`, etc. classes, but still define the necessary utility classes.
 
 Why MinGW has no threading classes 
-==================================
-It seems that for cross-platform threading implementation, the GCC standard library relies on
-the gthreads/pthreads library. If this library is not available, as is the case with MinGW, the
-std::thread, std::mutex, std::condition_variable are not defined. However, higher-level mutex
-helper classes are still defined in &lt;mutex&gt; and are usable. Hence, this implementation
-does not re-define them, and to use these helpers, you should include &lt;mutex&gt; as well, as explained
-in the usage section.
+----------------------------------
+It seems that for cross-platform threading implementation, the GCC standard library relies on the gthreads/pthreads library.
+If this library is not available, as is the case with MinGW, the classes `std::thread`, `std::mutex`, `std::condition_variable` are not defined.
+However, various usable helper classes are still defined in the system headers.
+Hence, this implementation does not re-define them, and instead includes those headers.
+

--- a/mingw.condition_variable.h
+++ b/mingw.condition_variable.h
@@ -27,11 +27,15 @@
 //  Use the standard classes for std::, if available.
 #include <condition_variable>
 
-#include <atomic>
 #include <cassert>
 #include <chrono>
 #include <system_error>
 #include <windows.h>
+
+#if (WINVER < _WIN32_WINNT_VISTA)
+#include <atomic>
+#endif
+
 #include "mingw.mutex.h"
 #include "mingw.shared_mutex.h"
 

--- a/mingw.mutex.h
+++ b/mingw.mutex.h
@@ -287,8 +287,8 @@ class recursive_timed_mutex
         assert(ms != INFINITE);
         return (WaitForSingleObject(mHandle, ms) == WAIT_OBJECT_0);
     }
-    HANDLE mHandle;
 protected:
+    HANDLE mHandle;
 //    Track locking thread for error checking of non-recursive timed_mutex. For
 //  standard compliance, this must be defined in same class and at the same
 //  access-control level as every other variable in the timed_mutex.

--- a/mingw.mutex.h
+++ b/mingw.mutex.h
@@ -38,7 +38,6 @@
 #include <system_error>
 #include <atomic>
 #include <mutex> //need for call_once()
-#include <algorithm>  //  For std::min
 
 #if STDMUTEX_RECURSION_CHECKS
 #include <cstdio>
@@ -335,7 +334,8 @@ public:
         auto timeout = duration_cast<milliseconds>(dur).count();
         while (timeout > 0)
         {
-          auto step = std::min(timeout, static_cast<decltype(timeout)>(INFINITE - 1));
+          constexpr auto kMaxStep = static_cast<decltype(timeout)>(INFINITE-1);
+          auto step = (timeout < kMaxStep) ? timeout : kMaxStep;
           if (try_lock_internal(static_cast<DWORD>(step)))
             return true;
           timeout -= step;

--- a/mingw.thread.h
+++ b/mingw.thread.h
@@ -27,24 +27,31 @@
 //  Use the standard classes for std::, if available.
 #include <thread>
 
-#include <functional>
-#include <memory>
-#include <chrono>
-#include <system_error>
-#include <cerrno>
-#include <ostream>
-#include <type_traits>
-#include <limits>
-#include <algorithm>
+#include <cstddef>      //  For std::size_t
+#include <cerrno>       //  Detect error type.
+#include <exception>    //  For std::terminate
+#include <system_error> //  For std::system_error
+#include <functional>   //  For std::hash
+#include <tuple>        //  For std::tuple
+#include <chrono>       //  For sleep timing.
+#include <memory>       //  For std::unique_ptr
+#include <ostream>      //  Stream output for thread ids.
+#include <utility>      //  For std::swap, std::forward
+#include <algorithm>    //  For std::min
+
+//  For the invoke implementation only:
+#include <type_traits>  //  For std::result_of, etc.
+//#include <utility>      //  For std::forward
+//#include <functional>   //  For std::reference_wrapper
 
 #include <windows.h>
-#include <process.h>  //  For beginthread
+#include <process.h>  //  For _beginthreadex
 
 #ifndef NDEBUG
 #include <cstdio>
 #endif
 
-//instead of INVALID_HANDLE_VALUE _beginthreadex returns 0
+//  Instead of INVALID_HANDLE_VALUE, _beginthreadex returns 0.
 namespace mingw_stdthread
 {
 namespace detail
@@ -164,7 +171,7 @@ namespace detail
         }
     };
 
-}
+} //  Namespace "detail"
 
 class thread
 {

--- a/mingw.thread.h
+++ b/mingw.thread.h
@@ -37,7 +37,6 @@
 #include <memory>       //  For std::unique_ptr
 #include <ostream>      //  Stream output for thread ids.
 #include <utility>      //  For std::swap, std::forward
-#include <algorithm>    //  For std::min
 
 //  For the invoke implementation only:
 #include <type_traits>  //  For std::result_of, etc.
@@ -340,7 +339,8 @@ namespace this_thread
         rep ms = duration_cast<milliseconds>(sleep_duration).count();
         while (ms > 0)
         {
-            auto sleepTime = std::min(ms, static_cast<rep>(INFINITE - 1));
+            constexpr rep kMaxRep = static_cast<rep>(INFINITE - 1);
+            auto sleepTime = (ms < kMaxRep) ? ms : kMaxRep;
             Sleep(static_cast<DWORD>(sleepTime));
             ms -= sleepTime;
         }

--- a/mingw.thread.h
+++ b/mingw.thread.h
@@ -27,18 +27,18 @@
 //  Use the standard classes for std::, if available.
 #include <thread>
 
-#include <windows.h>
 #include <functional>
 #include <memory>
 #include <chrono>
 #include <system_error>
 #include <cerrno>
 #include <ostream>
-#include <process.h>
-#include <ostream>
 #include <type_traits>
 #include <limits>
 #include <algorithm>
+
+#include <windows.h>
+#include <process.h>  //  For beginthread
 
 #ifndef NDEBUG
 #include <cstdio>
@@ -241,8 +241,6 @@ public:
         auto int_handle = _beginthreadex(NULL, 0, threadfunc<Call>,
             static_cast<LPVOID>(call), 0,
             reinterpret_cast<unsigned*>(&(mThreadId.mId)));
-        /*mHandle = (HANDLE)_beginthreadex(NULL, 0, threadfunc<Call>,
-            (LPVOID)call, 0, (unsigned*)&(mThreadId.mId));*/
         if (int_handle == 0)
         {
             mHandle = kInvalidHandle;

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -7,6 +7,7 @@
 #include <cassert>
 #include <string>
 #include <iostream>
+#include <typeinfo>
 #include <windows.h>
 
 using namespace std;
@@ -242,20 +243,36 @@ void test_future ()
   test_future_get_value(async_member);
 }
 
+#define TEST_SL_MV_CPY(ClassName) if (!std::is_standard_layout<ClassName>::value) \
+    LOG("WARNING: Class %s does not satisfy concept StandardLayoutType.","ClassName"); \
+    static_assert(!std::is_move_constructible<ClassName>::value, \
+                  "ClassName must not be move-constructible."); \
+    static_assert(!std::is_move_assignable<ClassName>::value, \
+                  "ClassName must not be move-assignable."); \
+    static_assert(!std::is_copy_constructible<ClassName>::value, \
+                  "ClassName must not be copy-constructible."); \
+    static_assert(!std::is_copy_assignable<ClassName>::value, \
+                  "ClassName must not be copy-assignable.");
+
 int main()
 {
-    if (!is_standard_layout<mutex>::value)
-      LOG("WARNING: Class std::%s does not satisfy concept StandardLayoutType.","mutex");
-    if (!is_standard_layout<recursive_mutex>::value)
-      LOG("WARNING: Class std::%s does not satisfy concept StandardLayoutType.","recursive_mutex");
-    if (!is_standard_layout<timed_mutex>::value)
-      LOG("WARNING: Class std::%s does not satisfy concept StandardLayoutType.","timed_mutex");
-    if (!is_standard_layout<recursive_timed_mutex>::value)
-      LOG("WARNING: Class std::%s does not satisfy concept StandardLayoutType.","recursive_timed_mutex");
-    if (!is_standard_layout<shared_mutex>::value)
-      LOG("WARNING: Class std::%s does not satisfy concept StandardLayoutType.","shared_mutex");
-    if (!is_standard_layout<shared_timed_mutex>::value)
-      LOG("WARNING: Class std::%s does not satisfy concept StandardLayoutType.","shared_timed_mutex");
+    TEST_SL_MV_CPY(mutex)
+    TEST_SL_MV_CPY(recursive_mutex)
+    TEST_SL_MV_CPY(timed_mutex)
+    TEST_SL_MV_CPY(recursive_timed_mutex)
+    TEST_SL_MV_CPY(shared_mutex)
+    TEST_SL_MV_CPY(shared_timed_mutex)
+    TEST_SL_MV_CPY(condition_variable)
+    TEST_SL_MV_CPY(condition_variable_any)
+    static_assert(!std::is_move_constructible<once_flag>::value,
+                  "once_flag must not be move-constructible.");
+    static_assert(!std::is_move_assignable<once_flag>::value,
+                  "once_flag must not be move-assignable.");
+    static_assert(!std::is_copy_constructible<once_flag>::value,
+                  "once_flag must not be copy-constructible.");
+    static_assert(!std::is_copy_assignable<once_flag>::value,
+                  "once_flag must not be copy-assignable.");
+
 //    With C++ feature level and target Windows version potentially affecting
 //  behavior, make this information visible.
     {


### PR DESCRIPTION
Bug fixes:
- Restore StandardLayout property to `timed_mutex` and `recursive_timed_mutex`, which had been lost in a previous commit. Add regression tests for this.
- Apply an alternate approach to resolving multiple-include errors; this fixes problems with compiling `"mingw.future.h"` that were not detected by tests.
- Ensure that the StandardLayout property is satisfied by `condition_variable` and `condition_variable_any`. Add regression tests for this.
- Cause the Windows XP `condition_variable` and `condition_variable_any` to throw an exception when construction fails, rather than silently failing.
- Include `<functional>` in `"mingw.future.h"` to ensure that `std::hash` is defined.
- Include all referenced headers in "mingw.thread.h" to ensure that changes to MinGW's implementation do not break the library.

Non-bug improvements:
- Statically initialize `condition_variable`s for Vista and higher. This may slightly improve performance when they are created.
- Reduce include burdens in individual files by omitting headers that won't be used under the given options.
- Remove `<algorithm>` dependency, to improve compile times.
