### PR TITLE
Descriptive error on insufficient Windows version.

### DIFF
--- a/mingw.mutex.h
+++ b/mingw.mutex.h
@@ -48,6 +48,10 @@
 //  Need for the implementation of invoke
 #include "mingw.thread.h"
 
+#if !defined(_WIN32_WINNT) || (_WIN32_WINNT < 0x0501)
+#error To use the MinGW-std-threads library, you will need to define the macro _WIN32_WINNT to be 0x0501 (Windows XP) or higher.
+#endif
+
 namespace mingw_stdthread
 {
 //    The _NonRecursive class has mechanisms that do not play nice with direct
@@ -161,6 +165,7 @@ public:
     mutex & operator= (const mutex&) = delete;
     void lock (void)
     {
+//  Note: Undefined behavior if called recursively.
 #if STDMUTEX_RECURSION_CHECKS
         DWORD self = mOwnerThread.checkOwnerBeforeLock();
 #endif
@@ -216,6 +221,9 @@ public:
     mutex & operator= (const mutex&) = delete;
     ~mutex() noexcept
     {
+//    Undefined behavior if the mutex is held (locked) by any thread.
+//    Undefined behavior if a thread terminates while holding ownership of the
+//  mutex.
         DeleteCriticalSection(&mHandle);
     }
     void lock (void)

--- a/mingw.shared_mutex.h
+++ b/mingw.shared_mutex.h
@@ -55,6 +55,10 @@
 //  Might be able to use native Slim Reader-Writer (SRW) locks.
 #ifdef _WIN32
 #include <windows.h>
+
+#if !defined(_WIN32_WINNT) || (_WIN32_WINNT < 0x0501)
+#error To use the MinGW-std-threads library, you will need to define the macro _WIN32_WINNT to be 0x0501 (Windows XP) or higher.
+#endif
 #endif
 
 namespace mingw_stdthread


### PR DESCRIPTION
- Give a descriptive error when the user is targeting a version of Windows that lacks features vital to the library. Specifically, if a version of Windows earlier than Windows XP is being targeted either intentionally or by default. Addresses #49.
- Change method of finding values not equal to `CONDITION_VARIABLE_LOCKMODE_SHARED`. The value to be used when this constant is _not_ desired is undocumented in Microsoft's website, as is the value of the constant itself. The change made here changes to generating a different value, instead of assuming (and asserting) a specific value.