### PR TITLE
Add -fno-exceptions support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,41 @@
 mingw-std-threads
 =================
 
-Standard C++11 threading classes implementation, which are currently still missing
-on MinGW GCC.
+Implementation of standard C++11 threading classes, which are currently still missing on MinGW GCC.
 
-Windows compatibility
-=====================
+Target Windows version
+----------------------
 This implementation should work with Windows XP (regardless of service pack), or newer.
-The library automatically detects the version of Windows that is being targeted, and selects an implementation that takes advantage of available Windows features. In MinGW GCC, the target Windows version may optionally be selected by the command-line option `-D _WIN32_WINNT=...`. Use `0x0600` for Windows Vista, or `0x0601` for Windows 7. See ["Modifying `WINVER` and `_WIN32_WINNT`](https://docs.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt).
+The library automatically detects the version of Windows that is being targeted (at compile time), and selects an implementation that takes advantage of available Windows features.
+In MinGW GCC, the target Windows version may optionally be selected by the command-line option `-D _WIN32_WINNT=...`.
+Use `0x0600` for Windows Vista, or `0x0601` for Windows 7.
+See "[Modifying `WINVER` and `_WIN32_WINNT`](https://docs.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt)" for more details.
 
 Usage
-=====
+-----
 
-This is a header-only library. To use, just include the corresponding mingw.xxx.h file, where
-xxx would be the name of the standard header that you would normally include.
-For additional mutex helper classes, such as std::scoped_guard or std::unique_lock, you need to
-include &lt;mutex&gt; before including mingw.mutex.h
+This is a header-only library. To use, just include the corresponding `mingw.xxx.h file`, where `xxx` would be the name of the standard header that you would normally include.
+
+For example, `#include "mingw.thread.h"` replaces `#include <thread>`.
 
 Compatibility
-=============
+-------------
 
-This code has been tested to work with MinGW-w64 5.3.0, but should work with any other MinGW version
-that has the std threading classes missing, has C++11 support for lambda functions, variadic
-templates, and has working mutex helper classes in &lt;mutex&gt;.  
+This code has been tested to work with MinGW-w64 5.3.0, but should work with any other MinGW version that has the `std` threading classes missing, has C++11 support for lambda functions, variadic templates, and has working mutex helper classes in `<mutex>`.
 
 Switching from the win32-pthread based implementation
-=====================================================
-It seems that recent versions of mingw-w64 include a win32 port of pthreads, and have
-the std::thread, std::mutex etc classes implemented and working, based on that compatibility
-layer. This is a somewhat heavier implementation, as it brings a not very thin abstraction layer.
-So you may still want to use this implementation for efficiency purposes. Unfortunately you can't use it
-standalone and independent of the system &lt;mutex&gt; header, as it relies on it for std::unique_lock and other
-non-trivial utility classes. In that case you will need to edit the c++-config.h file of your MinGW setup
-and comment out the definition of _GLIBCXX_HAS_GTHREADS. This will cause the system headers to not define the
-actual thread, mutex, etc classes, but still define the necessary utility classes.
+-----------------------------------------------------
+It seems that recent versions of MinGW-w64 include a Win32 port of pthreads, and have the `std::thread`, `std::mutex`, etc. classes implemented and working based on that compatibility
+layer.
+That is a somewhat heavier implementation, as it relies on an abstraction layer, so you may still want to use this implementation for efficiency purposes.
+Unfortunately you can't use this library standalone and independent of the system `<mutex>` headers, as it relies on those headers for `std::unique_lock` and other non-trivial utility classes.
+In that case you will need to edit the `c++-config.h` file of your MinGW setup and comment out the definition of _GLIBCXX_HAS_GTHREADS.
+This will cause the system headers not to define the actual `thread`, `mutex`, etc. classes, but still define the necessary utility classes.
 
 Why MinGW has no threading classes 
-==================================
-It seems that for cross-platform threading implementation, the GCC standard library relies on
-the gthreads/pthreads library. If this library is not available, as is the case with MinGW, the
-std::thread, std::mutex, std::condition_variable are not defined. However, higher-level mutex
-helper classes are still defined in &lt;mutex&gt; and are usable. Hence, this implementation
-does not re-define them, and to use these helpers, you should include &lt;mutex&gt; as well, as explained
-in the usage section.
+----------------------------------
+It seems that for cross-platform threading implementation, the GCC standard library relies on the gthreads/pthreads library.
+If this library is not available, as is the case with MinGW, the classes `std::thread`, `std::mutex`, `std::condition_variable` are not defined.
+However, various usable helper classes are still defined in the system headers.
+Hence, this implementation does not re-define them, and instead includes those headers.
+

--- a/mingw.condition_variable.h
+++ b/mingw.condition_variable.h
@@ -26,7 +26,7 @@
 #endif
 //  Use the standard classes for std::, if available.
 #include <condition_variable>
-
+#include <c++/bits/exception_defines.h>
 #include <cassert>
 #include <chrono>
 #include <system_error>
@@ -74,12 +74,12 @@ public:
         :   mSemaphore(CreateSemaphore(NULL, 0, 0xFFFF, NULL))
     {
         if (mSemaphore == NULL)
-            throw std::system_error(GetLastError(), std::generic_category());
+            __throw_exception_again std::system_error(GetLastError(), std::generic_category());
         mWakeEvent = CreateEvent(NULL, FALSE, FALSE, NULL);
         if (mWakeEvent == NULL)
         {
             CloseHandle(mSemaphore);
-            throw std::system_error(GetLastError(), std::generic_category());
+            __throw_exception_again std::system_error(GetLastError(), std::generic_category());
         }
     }
     ~condition_variable_any()
@@ -119,8 +119,9 @@ private:
         else
         {
             using namespace std;
-            throw system_error(make_error_code(errc::protocol_error));
+            __throw_exception_again system_error(make_error_code(errc::protocol_error));
         }
+		return false;
     }
 public:
     template <class M>

--- a/mingw.condition_variable.h
+++ b/mingw.condition_variable.h
@@ -38,6 +38,7 @@
 
 #include "mingw.mutex.h"
 #include "mingw.shared_mutex.h"
+#include "mingw.throw.h"
 
 #if !defined(_WIN32_WINNT) || (_WIN32_WINNT < 0x0501)
 #error To use the MinGW-std-threads library, you will need to define the macro _WIN32_WINNT to be 0x0501 (Windows XP) or higher.
@@ -74,12 +75,12 @@ public:
         :   mSemaphore(CreateSemaphore(NULL, 0, 0xFFFF, NULL))
     {
         if (mSemaphore == NULL)
-            std::__throw_system_error(GetLastError());
+            mingw_throw_system_error_arg(GetLastError(), std::generic_category());
         mWakeEvent = CreateEvent(NULL, FALSE, FALSE, NULL);
         if (mWakeEvent == NULL)
         {
             CloseHandle(mSemaphore);
-            std::__throw_system_error(GetLastError());
+            mingw_throw_system_error_arg(GetLastError(), std::generic_category());
         }
     }
     ~condition_variable_any()
@@ -119,7 +120,7 @@ private:
         else
         {
             using namespace std;
-            std::__throw_system_error(int(errc::protocol_error));
+            mingw_throw_system_error(mingw_make_error_code(errc::protocol_error));
         }
 		return false;
     }

--- a/mingw.condition_variable.h
+++ b/mingw.condition_variable.h
@@ -26,7 +26,7 @@
 #endif
 //  Use the standard classes for std::, if available.
 #include <condition_variable>
-#include <bits/exception_defines.h>
+
 #include <cassert>
 #include <chrono>
 #include <system_error>
@@ -74,12 +74,12 @@ public:
         :   mSemaphore(CreateSemaphore(NULL, 0, 0xFFFF, NULL))
     {
         if (mSemaphore == NULL)
-            __throw_exception_again std::system_error(GetLastError(), std::generic_category());
+            std::__throw_system_error(GetLastError());
         mWakeEvent = CreateEvent(NULL, FALSE, FALSE, NULL);
         if (mWakeEvent == NULL)
         {
             CloseHandle(mSemaphore);
-            __throw_exception_again std::system_error(GetLastError(), std::generic_category());
+            std::__throw_system_error(GetLastError());
         }
     }
     ~condition_variable_any()
@@ -119,7 +119,7 @@ private:
         else
         {
             using namespace std;
-            __throw_exception_again system_error(make_error_code(errc::protocol_error));
+            std::__throw_system_error(int(errc::protocol_error));
         }
 		return false;
     }

--- a/mingw.condition_variable.h
+++ b/mingw.condition_variable.h
@@ -27,11 +27,15 @@
 //  Use the standard classes for std::, if available.
 #include <condition_variable>
 
-#include <atomic>
 #include <cassert>
 #include <chrono>
 #include <system_error>
 #include <windows.h>
+
+#if (WINVER < _WIN32_WINNT_VISTA)
+#include <atomic>
+#endif
+
 #include "mingw.mutex.h"
 #include "mingw.shared_mutex.h"
 
@@ -50,12 +54,12 @@ namespace xp
 #if (WINVER < _WIN32_WINNT_VISTA)
 class condition_variable_any
 {
-    recursive_mutex mMutex;
-    std::atomic<int> mNumWaiters;
+    recursive_mutex mMutex {};
+    std::atomic<int> mNumWaiters {0};
     HANDLE mSemaphore;
-    HANDLE mWakeEvent;
+    HANDLE mWakeEvent {};
 public:
-    typedef HANDLE native_handle_type;
+    using native_handle_type = HANDLE;
     native_handle_type native_handle()
     {
         return mSemaphore;
@@ -63,10 +67,17 @@ public:
     condition_variable_any(const condition_variable_any&) = delete;
     condition_variable_any& operator=(const condition_variable_any&) = delete;
     condition_variable_any()
-        :mMutex(), mNumWaiters(0),
-         mSemaphore(CreateSemaphore(NULL, 0, 0xFFFF, NULL)),
-         mWakeEvent(CreateEvent(NULL, FALSE, FALSE, NULL))
-    {}
+        :   mSemaphore(CreateSemaphore(NULL, 0, 0xFFFF, NULL))
+    {
+        if (mSemaphore == NULL)
+            throw std::system_error(GetLastError(), std::generic_category());
+        mWakeEvent = CreateEvent(NULL, FALSE, FALSE, NULL);
+        if (mWakeEvent == NULL)
+        {
+            CloseHandle(mSemaphore);
+            throw std::system_error(GetLastError(), std::generic_category());
+        }
+    }
     ~condition_variable_any()
     {
         CloseHandle(mWakeEvent);
@@ -198,7 +209,7 @@ public:
 };
 class condition_variable: condition_variable_any
 {
-    typedef condition_variable_any base;
+    using base = condition_variable_any;
 public:
     using base::native_handle_type;
     using base::native_handle;
@@ -244,7 +255,12 @@ namespace vista
 //  If compiling for Vista or higher, use the native condition variable.
 class condition_variable
 {
-    CONDITION_VARIABLE cvariable_;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
+    CONDITION_VARIABLE cvariable_ = CONDITION_VARIABLE_INIT;
+#pragma GCC diagnostic pop
+
+    friend class condition_variable_any;
 
 #if STDMUTEX_RECURSION_CHECKS
     template<typename MTX>
@@ -262,7 +278,6 @@ class condition_variable
     inline static void after_wait (void *) { }
 #endif
 
-protected:
     bool wait_impl (unique_lock<xp::mutex> & lock, DWORD time)
     {
         static_assert(std::is_same<typename xp::mutex::native_handle_type, PCRITICAL_SECTION>::value,
@@ -295,18 +310,13 @@ use native Win32 critical section objects.");
         return success;
     }
 public:
-    typedef PCONDITION_VARIABLE native_handle_type;
+    using native_handle_type = PCONDITION_VARIABLE;
     native_handle_type native_handle (void)
     {
         return &cvariable_;
     }
 
-    condition_variable (void)
-        : cvariable_()
-    {
-        InitializeConditionVariable(&cvariable_);
-    }
-
+    condition_variable (void) = default;
     ~condition_variable (void) = default;
 
     condition_variable (const condition_variable &) = delete;
@@ -376,22 +386,22 @@ public:
     }
 };
 
-class condition_variable_any : condition_variable
+class condition_variable_any
 {
-    typedef condition_variable base;
-    typedef windows7::shared_mutex native_shared_mutex;
+    using native_shared_mutex = windows7::shared_mutex;
 
+    condition_variable internal_cv_ {};
 //    When available, the SRW-based mutexes should be faster than the
 //  CriticalSection-based mutexes. Only try_lock will be unavailable in Vista,
 //  and try_lock is not used by condition_variable_any.
-    windows7::mutex internal_mutex_;
+    windows7::mutex internal_mutex_ {};
 
     template<class L>
     bool wait_impl (L & lock, DWORD time)
     {
         unique_lock<decltype(internal_mutex_)> internal_lock(internal_mutex_);
         lock.unlock();
-        bool success = base::wait_impl(internal_lock, time);
+        bool success = internal_cv_.wait_impl(internal_lock, time);
         lock.lock();
         return success;
     }
@@ -399,7 +409,7 @@ class condition_variable_any : condition_variable
 //  contention.
     inline bool wait_impl (unique_lock<mutex> & lock, DWORD time)
     {
-        return base::wait_impl(lock, time);
+        return internal_cv_.wait_impl(lock, time);
     }
 //    Some shared_mutex functionality is available even in Vista, but it's not
 //  until Windows 7 that a full implementation is natively possible. The class
@@ -411,32 +421,39 @@ to be 0. There is a conflict with CONDITION_VARIABLE_LOCKMODE_SHARED.");
     bool wait_impl (unique_lock<native_shared_mutex> & lock, DWORD time)
     {
         native_shared_mutex * pmutex = lock.release();
-        bool success = wait_unique(pmutex, time);
+        bool success = internal_cv_.wait_unique(pmutex, time);
         lock = unique_lock<native_shared_mutex>(*pmutex, adopt_lock);
         return success;
     }
     bool wait_impl (shared_lock<native_shared_mutex> & lock, DWORD time)
     {
         native_shared_mutex * pmutex = lock.release();
-        BOOL success = SleepConditionVariableSRW( base::native_handle(),
+        BOOL success = SleepConditionVariableSRW(native_handle(),
                        pmutex->native_handle(), time,
                        CONDITION_VARIABLE_LOCKMODE_SHARED);
         lock = shared_lock<native_shared_mutex>(*pmutex, adopt_lock);
         return success;
     }
 public:
-    typedef typename base::native_handle_type native_handle_type;
-    using base::native_handle;
+    using native_handle_type = typename condition_variable::native_handle_type;
 
-    condition_variable_any (void)
-        : base(), internal_mutex_()
+    native_handle_type native_handle (void)
     {
+        return internal_cv_.native_handle();
     }
 
-    ~condition_variable_any (void) = default;
+    void notify_one (void) noexcept
+    {
+        internal_cv_.notify_one();
+    }
 
-    using base::notify_one;
-    using base::notify_all;
+    void notify_all (void) noexcept
+    {
+        internal_cv_.notify_all();
+    }
+
+    condition_variable_any (void) = default;
+    ~condition_variable_any (void) = default;
 
     template<class L>
     void wait (L & lock)

--- a/mingw.condition_variable.h
+++ b/mingw.condition_variable.h
@@ -26,7 +26,7 @@
 #endif
 //  Use the standard classes for std::, if available.
 #include <condition_variable>
-#include <c++/bits/exception_defines.h>
+#include <bits/exception_defines.h>
 #include <cassert>
 #include <chrono>
 #include <system_error>

--- a/mingw.future.h
+++ b/mingw.future.h
@@ -33,6 +33,7 @@
 //  Mutexes and condition variables are used explicitly.
 #include "mingw.mutex.h"
 #include "mingw.condition_variable.h"
+#include "mingw.throw.h"
 
 //  Note:
 //    std::shared_ptr is the natural choice for this. However, a custom
@@ -173,7 +174,7 @@ struct FutureBase : public FutureStatic<true>
   {
 #if !defined(NDEBUG)
     if (!valid())
-      __throw_future_error(future_errc::no_state);
+      mingw_throw_future_error(future_errc::no_state);
 #endif
 //    If there's already a value or exception, don't do any extraneous
 //  synchronization. The `get()` method will do that for us.
@@ -189,7 +190,7 @@ struct FutureBase : public FutureStatic<true>
   {
 #if !defined(NDEBUG)
     if (!valid())
-      __throw_future_error(future_errc::no_state);
+      mingw_throw_future_error(future_errc::no_state);
 #endif
     auto current_state = mState->mType.load(std::memory_order_relaxed);
     if (current_state & kReadyFlag)
@@ -464,9 +465,9 @@ class promise : mingw_stdthread::detail::FutureBase
   void check_before_set (void) const
   {
     if (!valid())
-      __throw_future_error(future_errc::no_state);
+      mingw_throw_future_error(future_errc::no_state);
     if (mState->mType.load(std::memory_order_relaxed) & kSetFlag)
-      __throw_future_error(future_errc::promise_already_satisfied);
+      mingw_throw_future_error(future_errc::promise_already_satisfied);
   }
 
   void check_abandon (void)
@@ -474,7 +475,7 @@ class promise : mingw_stdthread::detail::FutureBase
     if (valid() && !(mState->mType.load(std::memory_order_relaxed) & kSetFlag))
     {
       try {
-        __throw_future_error(future_errc::broken_promise);
+        mingw_throw_future_error(future_errc::broken_promise);
       } catch (...) {
         set_exception(std::current_exception());
       }
@@ -494,7 +495,7 @@ class promise : mingw_stdthread::detail::FutureBase
                                    FALSE, //  No need for this to be inherited.
                                    DUPLICATE_SAME_ACCESS | DUPLICATE_CLOSE_SOURCE);
     if (!success)
-      __throw_runtime_error("MinGW STD Threads library failed to make a promise ready after thread exit.");
+      mingw_throw_runtime_error("MinGW STD Threads library failed to make a promise ready after thread exit.");
 
     mState->increment_references();
     bool handle_handled = false;
@@ -542,9 +543,9 @@ class promise : mingw_stdthread::detail::FutureBase
   future<U> make_future (void)
   {
     if (!valid())
-      __throw_future_error(future_errc::no_state);
+      mingw_throw_future_error(future_errc::no_state);
     if (mRetrieved)
-      __throw_future_error(future_errc::future_already_retrieved);
+      mingw_throw_future_error(future_errc::future_already_retrieved);
     mState->increment_references();
     mRetrieved = true;
     return future<U>(static_cast<state_type *>(mState));

--- a/mingw.future.h
+++ b/mingw.future.h
@@ -20,7 +20,7 @@
 #endif
 
 #include <future>
-#include <c++/bits/exception_defines.h>
+#include <bits/exception_defines.h>
 #include <cassert>
 #include <vector>
 #include <utility>        //  For std::pair

--- a/mingw.future.h
+++ b/mingw.future.h
@@ -20,7 +20,7 @@
 #endif
 
 #include <future>
-
+#include <c++/bits/exception_defines.h>
 #include <cassert>
 #include <vector>
 #include <utility>        //  For std::pair
@@ -173,7 +173,7 @@ struct FutureBase : public FutureStatic<true>
   {
 #if !defined(NDEBUG)
     if (!valid())
-      throw future_error(future_errc::no_state);
+      __throw_exception_again future_error(future_errc::no_state);
 #endif
 //    If there's already a value or exception, don't do any extraneous
 //  synchronization. The `get()` method will do that for us.
@@ -189,7 +189,7 @@ struct FutureBase : public FutureStatic<true>
   {
 #if !defined(NDEBUG)
     if (!valid())
-      throw future_error(future_errc::no_state);
+      __throw_exception_again future_error(future_errc::no_state);
 #endif
     auto current_state = mState->mType.load(std::memory_order_relaxed);
     if (current_state & kReadyFlag)
@@ -464,9 +464,9 @@ class promise : mingw_stdthread::detail::FutureBase
   void check_before_set (void) const
   {
     if (!valid())
-      throw future_error(future_errc::no_state);
+      __throw_exception_again future_error(future_errc::no_state);
     if (mState->mType.load(std::memory_order_relaxed) & kSetFlag)
-      throw future_error(future_errc::promise_already_satisfied);
+      __throw_exception_again future_error(future_errc::promise_already_satisfied);
   }
 
   void check_abandon (void)
@@ -474,13 +474,13 @@ class promise : mingw_stdthread::detail::FutureBase
     if (valid() && !(mState->mType.load(std::memory_order_relaxed) & kSetFlag))
     {
       try {
-        throw future_error(future_errc::broken_promise);
+        __throw_exception_again future_error(future_errc::broken_promise);
       } catch (...) {
         set_exception(std::current_exception());
       }
     }
   }
-/// \bug Might throw more exceptions than specified by the standard...
+/// \bug Might __throw_exception_again more exceptions than specified by the standard...
 //  Need OS support for this...
   void make_ready_at_thread_exit (void)
   {
@@ -494,7 +494,7 @@ class promise : mingw_stdthread::detail::FutureBase
                                    FALSE, //  No need for this to be inherited.
                                    DUPLICATE_SAME_ACCESS | DUPLICATE_CLOSE_SOURCE);
     if (!success)
-      throw std::runtime_error("MinGW STD Threads library failed to make a promise ready after thread exit.");
+      __throw_exception_again std::runtime_error("MinGW STD Threads library failed to make a promise ready after thread exit.");
 
     mState->increment_references();
     bool handle_handled = false;
@@ -542,9 +542,9 @@ class promise : mingw_stdthread::detail::FutureBase
   future<U> make_future (void)
   {
     if (!valid())
-      throw future_error(future_errc::no_state);
+      __throw_exception_again future_error(future_errc::no_state);
     if (mRetrieved)
-      throw future_error(future_errc::future_already_retrieved);
+      __throw_exception_again future_error(future_errc::future_already_retrieved);
     mState->increment_references();
     mRetrieved = true;
     return future<U>(static_cast<state_type *>(mState));

--- a/mingw.mutex.h
+++ b/mingw.mutex.h
@@ -34,6 +34,7 @@
 #define STDMUTEX_RECURSION_CHECKS 1
 #endif
 
+#include <c++/bits/exception_defines.h>
 #include <chrono>
 #include <system_error>
 #include <atomic>
@@ -118,7 +119,7 @@ struct _OwnerThread
         fprintf(stderr, "FATAL: Recursive locking of non-recursive mutex\
  detected. Throwing system exception\n");
         fflush(stderr);
-        throw system_error(make_error_code(errc::resource_deadlock_would_occur));
+        __throw_exception_again system_error(make_error_code(errc::resource_deadlock_would_occur));
     }
     DWORD checkOwnerBeforeLock() const
     {
@@ -339,13 +340,13 @@ public:
 #endif
         if ((ret != WAIT_OBJECT_0) && (ret != WAIT_ABANDONED))
         {
-            throw std::system_error(GetLastError(), std::system_category());
+            __throw_exception_again std::system_error(GetLastError(), std::system_category());
         }
     }
     void unlock()
     {
         if (!ReleaseMutex(mHandle))
-            throw std::system_error(GetLastError(), std::system_category());
+            __throw_exception_again std::system_error(GetLastError(), std::system_category());
     }
     bool try_lock()
     {

--- a/mingw.mutex.h
+++ b/mingw.mutex.h
@@ -34,7 +34,7 @@
 #define STDMUTEX_RECURSION_CHECKS 1
 #endif
 
-#include <c++/bits/exception_defines.h>
+#include <bits/exception_defines.h>
 #include <chrono>
 #include <system_error>
 #include <atomic>

--- a/mingw.mutex.h
+++ b/mingw.mutex.h
@@ -48,6 +48,7 @@
 
 //  Need for the implementation of invoke
 #include "mingw.thread.h"
+#include "mingw.throw.h"
 
 #if !defined(_WIN32_WINNT) || (_WIN32_WINNT < 0x0501)
 #error To use the MinGW-std-threads library, you will need to define the macro _WIN32_WINNT to be 0x0501 (Windows XP) or higher.
@@ -119,7 +120,7 @@ struct _OwnerThread
         fprintf(stderr, "FATAL: Recursive locking of non-recursive mutex\
  detected. Throwing system exception\n");
         fflush(stderr);
-        std::__throw_system_error(int(errc::resource_deadlock_would_occur));
+        mingw_throw_system_error(mingw_make_error_code(errc::resource_deadlock_would_occur));
     }
     DWORD checkOwnerBeforeLock() const
     {
@@ -340,13 +341,13 @@ public:
 #endif
         if ((ret != WAIT_OBJECT_0) && (ret != WAIT_ABANDONED))
         {
-            std::__throw_system_error(GetLastError());
+            mingw_throw_system_error_arg(GetLastError(), std::system_category());
         }
     }
     void unlock()
     {
         if (!ReleaseMutex(mHandle))
-            std::__throw_system_error(GetLastError());
+            mingw_throw_system_error_arg(GetLastError(), std::system_category());
     }
     bool try_lock()
     {

--- a/mingw.mutex.h
+++ b/mingw.mutex.h
@@ -34,7 +34,7 @@
 #define STDMUTEX_RECURSION_CHECKS 1
 #endif
 
-#include <bits/exception_defines.h>
+
 #include <chrono>
 #include <system_error>
 #include <atomic>
@@ -119,7 +119,7 @@ struct _OwnerThread
         fprintf(stderr, "FATAL: Recursive locking of non-recursive mutex\
  detected. Throwing system exception\n");
         fflush(stderr);
-        __throw_exception_again system_error(make_error_code(errc::resource_deadlock_would_occur));
+        std::__throw_system_error(int(errc::resource_deadlock_would_occur));
     }
     DWORD checkOwnerBeforeLock() const
     {
@@ -340,13 +340,13 @@ public:
 #endif
         if ((ret != WAIT_OBJECT_0) && (ret != WAIT_ABANDONED))
         {
-            __throw_exception_again std::system_error(GetLastError(), std::system_category());
+            std::__throw_system_error(GetLastError());
         }
     }
     void unlock()
     {
         if (!ReleaseMutex(mHandle))
-            __throw_exception_again std::system_error(GetLastError(), std::system_category());
+            std::__throw_system_error(GetLastError());
     }
     bool try_lock()
     {

--- a/mingw.shared_mutex.h
+++ b/mingw.shared_mutex.h
@@ -53,6 +53,7 @@
 #include "mingw.mutex.h"
 //  For this_thread::yield.
 #include "mingw.thread.h"
+#include "mingw.throw.h"
 
 //  Might be able to use native Slim Reader-Writer (SRW) locks.
 #ifdef _WIN32
@@ -129,7 +130,7 @@ public:
         using namespace std;
 #ifndef NDEBUG
         if (!(mCounter.fetch_sub(1, memory_order_release) & static_cast<counter_type>(~kWriteBit)))
-            std::__throw_system_error(int(errc::operation_not_permitted));
+            mingw_throw_system_error(mingw_make_error_code(errc::operation_not_permitted));
 #else
         mCounter.fetch_sub(1, memory_order_release);
 #endif
@@ -182,7 +183,7 @@ public:
         using namespace std;
 #ifndef NDEBUG
         if (mCounter.load(memory_order_relaxed) != kWriteBit)
-            std::__throw_system_error(int(errc::operation_not_permitted));
+            mingw_throw_system_error(mingw_make_error_code(errc::operation_not_permitted));
 #endif
         mCounter.store(0, memory_order_release);
     }
@@ -312,9 +313,9 @@ class shared_lock
     {
         using namespace std;
         if (mMutex == nullptr)
-            std::__throw_system_error(int(errc::operation_not_permitted));
+            mingw_throw_system_error(mingw_make_error_code(errc::operation_not_permitted));
         if (mOwns)
-            std::__throw_system_error(int(errc::resource_deadlock_would_occur));
+            mingw_throw_system_error(mingw_make_error_code(errc::resource_deadlock_would_occur));
     }
 public:
     typedef Mutex mutex_type;
@@ -427,7 +428,7 @@ public:
     {
         using namespace std;
         if (!mOwns)
-            std::__throw_system_error(int(errc::operation_not_permitted));
+            mingw_throw_system_error(mingw_make_error_code(errc::operation_not_permitted));
         mMutex->unlock_shared();
         mOwns = false;
     }

--- a/mingw.shared_mutex.h
+++ b/mingw.shared_mutex.h
@@ -31,7 +31,7 @@
 #error A C++11 compiler is required!
 #endif
 
-#include <c++/bits/exception_defines.h>
+#include <bits/exception_defines.h>
 #include <cassert>
 //  For descriptive errors.
 #include <system_error>

--- a/mingw.shared_mutex.h
+++ b/mingw.shared_mutex.h
@@ -31,6 +31,7 @@
 #error A C++11 compiler is required!
 #endif
 
+#include <c++/bits/exception_defines.h>
 #include <cassert>
 //  For descriptive errors.
 #include <system_error>
@@ -128,7 +129,7 @@ public:
         using namespace std;
 #ifndef NDEBUG
         if (!(mCounter.fetch_sub(1, memory_order_release) & static_cast<counter_type>(~kWriteBit)))
-            throw system_error(make_error_code(errc::operation_not_permitted));
+            __throw_exception_again system_error(make_error_code(errc::operation_not_permitted));
 #else
         mCounter.fetch_sub(1, memory_order_release);
 #endif
@@ -181,7 +182,7 @@ public:
         using namespace std;
 #ifndef NDEBUG
         if (mCounter.load(memory_order_relaxed) != kWriteBit)
-            throw system_error(make_error_code(errc::operation_not_permitted));
+            __throw_exception_again system_error(make_error_code(errc::operation_not_permitted));
 #endif
         mCounter.store(0, memory_order_release);
     }
@@ -311,9 +312,9 @@ class shared_lock
     {
         using namespace std;
         if (mMutex == nullptr)
-            throw system_error(make_error_code(errc::operation_not_permitted));
+            __throw_exception_again system_error(make_error_code(errc::operation_not_permitted));
         if (mOwns)
-            throw system_error(make_error_code(errc::resource_deadlock_would_occur));
+            __throw_exception_again system_error(make_error_code(errc::resource_deadlock_would_occur));
     }
 public:
     typedef Mutex mutex_type;
@@ -426,7 +427,7 @@ public:
     {
         using namespace std;
         if (!mOwns)
-            throw system_error(make_error_code(errc::operation_not_permitted));
+            __throw_exception_again system_error(make_error_code(errc::operation_not_permitted));
         mMutex->unlock_shared();
         mOwns = false;
     }

--- a/mingw.shared_mutex.h
+++ b/mingw.shared_mutex.h
@@ -31,7 +31,7 @@
 #error A C++11 compiler is required!
 #endif
 
-#include <bits/exception_defines.h>
+
 #include <cassert>
 //  For descriptive errors.
 #include <system_error>
@@ -129,7 +129,7 @@ public:
         using namespace std;
 #ifndef NDEBUG
         if (!(mCounter.fetch_sub(1, memory_order_release) & static_cast<counter_type>(~kWriteBit)))
-            __throw_exception_again system_error(make_error_code(errc::operation_not_permitted));
+            std::__throw_system_error(int(errc::operation_not_permitted));
 #else
         mCounter.fetch_sub(1, memory_order_release);
 #endif
@@ -182,7 +182,7 @@ public:
         using namespace std;
 #ifndef NDEBUG
         if (mCounter.load(memory_order_relaxed) != kWriteBit)
-            __throw_exception_again system_error(make_error_code(errc::operation_not_permitted));
+            std::__throw_system_error(int(errc::operation_not_permitted));
 #endif
         mCounter.store(0, memory_order_release);
     }
@@ -312,9 +312,9 @@ class shared_lock
     {
         using namespace std;
         if (mMutex == nullptr)
-            __throw_exception_again system_error(make_error_code(errc::operation_not_permitted));
+            std::__throw_system_error(int(errc::operation_not_permitted));
         if (mOwns)
-            __throw_exception_again system_error(make_error_code(errc::resource_deadlock_would_occur));
+            std::__throw_system_error(int(errc::resource_deadlock_would_occur));
     }
 public:
     typedef Mutex mutex_type;
@@ -427,7 +427,7 @@ public:
     {
         using namespace std;
         if (!mOwns)
-            __throw_exception_again system_error(make_error_code(errc::operation_not_permitted));
+            std::__throw_system_error(int(errc::operation_not_permitted));
         mMutex->unlock_shared();
         mOwns = false;
     }

--- a/mingw.thread.h
+++ b/mingw.thread.h
@@ -26,7 +26,7 @@
 
 //  Use the standard classes for std::, if available.
 #include <thread>
-
+#include <c++/bits/exception_defines.h>
 #include <cstddef>      //  For std::size_t
 #include <cerrno>       //  Detect error type.
 #include <exception>    //  For std::terminate
@@ -263,8 +263,8 @@ public:
             mHandle = kInvalidHandle;
             int errnum = errno;
             delete call;
-//  Note: Should only throw EINVAL, EAGAIN, EACCES
-            throw std::system_error(errnum, std::generic_category());
+//  Note: Should only __throw_exception_again EINVAL, EAGAIN, EACCES
+            __throw_exception_again std::system_error(errnum, std::generic_category());
         } else
             mHandle = reinterpret_cast<HANDLE>(int_handle);
     }
@@ -279,11 +279,11 @@ public:
     {
         using namespace std;
         if (get_id() == id(GetCurrentThreadId()))
-            throw system_error(make_error_code(errc::resource_deadlock_would_occur));
+            __throw_exception_again system_error(make_error_code(errc::resource_deadlock_would_occur));
         if (mHandle == kInvalidHandle)
-            throw system_error(make_error_code(errc::no_such_process));
+            __throw_exception_again system_error(make_error_code(errc::no_such_process));
         if (!joinable())
-            throw system_error(make_error_code(errc::invalid_argument));
+            __throw_exception_again system_error(make_error_code(errc::invalid_argument));
         WaitForSingleObject(mHandle, INFINITE);
         CloseHandle(mHandle);
         mHandle = kInvalidHandle;
@@ -332,7 +332,7 @@ moving another thread to it.\n");
         if (!joinable())
         {
             using namespace std;
-            throw system_error(make_error_code(errc::invalid_argument));
+            __throw_exception_again system_error(make_error_code(errc::invalid_argument));
         }
         if (mHandle != kInvalidHandle)
         {

--- a/mingw.thread.h
+++ b/mingw.thread.h
@@ -26,7 +26,7 @@
 
 //  Use the standard classes for std::, if available.
 #include <thread>
-#include <bits/exception_defines.h>
+
 #include <cstddef>      //  For std::size_t
 #include <cerrno>       //  Detect error type.
 #include <exception>    //  For std::terminate
@@ -263,8 +263,8 @@ public:
             mHandle = kInvalidHandle;
             int errnum = errno;
             delete call;
-//  Note: Should only __throw_exception_again EINVAL, EAGAIN, EACCES
-            __throw_exception_again std::system_error(errnum, std::generic_category());
+//  Note: Should only throw EINVAL, EAGAIN, EACCES
+            std::__throw_system_error(errnum);
         } else
             mHandle = reinterpret_cast<HANDLE>(int_handle);
     }
@@ -279,11 +279,11 @@ public:
     {
         using namespace std;
         if (get_id() == id(GetCurrentThreadId()))
-            __throw_exception_again system_error(make_error_code(errc::resource_deadlock_would_occur));
+            std::__throw_system_error(int(errc::resource_deadlock_would_occur));
         if (mHandle == kInvalidHandle)
-            __throw_exception_again system_error(make_error_code(errc::no_such_process));
+            std::__throw_system_error(int(errc::no_such_process));
         if (!joinable())
-            __throw_exception_again system_error(make_error_code(errc::invalid_argument));
+            std::__throw_system_error(int(errc::invalid_argument));
         WaitForSingleObject(mHandle, INFINITE);
         CloseHandle(mHandle);
         mHandle = kInvalidHandle;
@@ -332,7 +332,7 @@ moving another thread to it.\n");
         if (!joinable())
         {
             using namespace std;
-            __throw_exception_again system_error(make_error_code(errc::invalid_argument));
+            std::__throw_system_error(int(errc::invalid_argument));
         }
         if (mHandle != kInvalidHandle)
         {

--- a/mingw.thread.h
+++ b/mingw.thread.h
@@ -50,6 +50,8 @@
 #include <cstdio>
 #endif
 
+#include "mingw.throw.h"
+
 #if !defined(_WIN32_WINNT) || (_WIN32_WINNT < 0x0501)
 #error To use the MinGW-std-threads library, you will need to define the macro _WIN32_WINNT to be 0x0501 (Windows XP) or higher.
 #endif
@@ -264,7 +266,7 @@ public:
             int errnum = errno;
             delete call;
 //  Note: Should only throw EINVAL, EAGAIN, EACCES
-            std::__throw_system_error(errnum);
+            mingw_throw_system_error_arg(errnum, std::generic_category());
         } else
             mHandle = reinterpret_cast<HANDLE>(int_handle);
     }
@@ -279,11 +281,11 @@ public:
     {
         using namespace std;
         if (get_id() == id(GetCurrentThreadId()))
-            std::__throw_system_error(int(errc::resource_deadlock_would_occur));
+            mingw_throw_system_error(mingw_make_error_code(errc::resource_deadlock_would_occur));
         if (mHandle == kInvalidHandle)
-            std::__throw_system_error(int(errc::no_such_process));
+            mingw_throw_system_error(mingw_make_error_code(errc::no_such_process));
         if (!joinable())
-            std::__throw_system_error(int(errc::invalid_argument));
+            mingw_throw_system_error(mingw_make_error_code(errc::invalid_argument));
         WaitForSingleObject(mHandle, INFINITE);
         CloseHandle(mHandle);
         mHandle = kInvalidHandle;
@@ -332,7 +334,7 @@ moving another thread to it.\n");
         if (!joinable())
         {
             using namespace std;
-            std::__throw_system_error(int(errc::invalid_argument));
+            mingw_throw_system_error(mingw_make_error_code(errc::invalid_argument));
         }
         if (mHandle != kInvalidHandle)
         {

--- a/mingw.thread.h
+++ b/mingw.thread.h
@@ -26,7 +26,7 @@
 
 //  Use the standard classes for std::, if available.
 #include <thread>
-#include <c++/bits/exception_defines.h>
+#include <bits/exception_defines.h>
 #include <cstddef>      //  For std::size_t
 #include <cerrno>       //  Detect error type.
 #include <exception>    //  For std::terminate

--- a/mingw.throw.h
+++ b/mingw.throw.h
@@ -1,0 +1,55 @@
+/**
+* @file mingw.throw.h
+* @brief throw helper to enable -fno-exceptions
+* (c) 2013-2016 by Mega Limited, Auckland, New Zealand
+* @author Maeiky
+*
+* @copyright Simplified (2-clause) BSD License.
+* You should have received a copy of the license along with this
+* program.
+*
+* This code is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* @note
+* This file may become part of the mingw-w64 runtime package. If/when this happens,
+* the appropriate license will be added, i.e. this code will become dual-licensed,
+* and the current BSD 2-clause license will stay.
+*/
+
+#ifndef MINGW_THROW_H_
+#define MINGW_THROW_H_
+
+#if !defined(__cplusplus) || (__cplusplus < 201103L)
+#error A C++11 compiler is required!
+#endif
+	
+// (Multi args version)
+//#define mingw_throw_multi(_1,_2,NAME,...) NAME
+//#define mingw_throw_system_error(...) mingw_throw_multi(__VA_ARGS__,  mingw_throw_system_error2, mingw_throw_system_error1)(__VA_ARGS__)
+
+	
+#ifdef __cpp_exceptions
+
+	#define mingw_make_error_code(err) 			     std::make_error_code(err)
+
+	#define mingw_throw_system_error(err)   	     throw std::system_error(err)
+	#define mingw_throw_system_error_arg(err, arg)   throw std::system_error(err, arg)
+	
+	#define mingw_throw_future_error(err)   	     throw std::future_error(err)
+	#define mingw_throw_runtime_error(err)  	     throw std::runtime_error(err)
+	
+#else
+	
+	#define mingw_make_error_code(err) 			     int(err)
+
+	#define mingw_throw_system_error(err)   	     std::__throw_system_error(err)
+	#define mingw_throw_system_error_arg(err, arg)   std::__throw_system_error(err)
+	
+	#define mingw_throw_future_error(err)   	     std::__throw_future_error(err)
+	#define mingw_throw_runtime_error(err)  	     std::__throw_runtime_error(err)
+	
+#endif
+	
+	
+#endif // MINGW_THROW_H_

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -7,6 +7,7 @@
 #include <cassert>
 #include <string>
 #include <iostream>
+#include <typeinfo>
 #include <windows.h>
 
 using namespace std;
@@ -242,20 +243,36 @@ void test_future ()
   test_future_get_value(async_member);
 }
 
+#define TEST_SL_MV_CPY(ClassName) if (!std::is_standard_layout<ClassName>::value) \
+    LOG("WARNING: Class %s does not satisfy concept StandardLayoutType.","ClassName"); \
+    static_assert(!std::is_move_constructible<ClassName>::value, \
+                  "ClassName must not be move-constructible."); \
+    static_assert(!std::is_move_assignable<ClassName>::value, \
+                  "ClassName must not be move-assignable."); \
+    static_assert(!std::is_copy_constructible<ClassName>::value, \
+                  "ClassName must not be copy-constructible."); \
+    static_assert(!std::is_copy_assignable<ClassName>::value, \
+                  "ClassName must not be copy-assignable.");
+
 int main()
 {
-    if (!is_standard_layout<mutex>::value)
-      LOG("WARNING: Class std::%s does not satisfy concept StandardLayoutType.","mutex");
-    if (!is_standard_layout<recursive_mutex>::value)
-      LOG("WARNING: Class std::%s does not satisfy concept StandardLayoutType.","recursive_mutex");
-    if (!is_standard_layout<timed_mutex>::value)
-      LOG("WARNING: Class std::%s does not satisfy concept StandardLayoutType.","timed_mutex");
-    if (!is_standard_layout<recursive_timed_mutex>::value)
-      LOG("WARNING: Class std::%s does not satisfy concept StandardLayoutType.","recursive_timed_mutex");
-    if (!is_standard_layout<shared_mutex>::value)
-      LOG("WARNING: Class std::%s does not satisfy concept StandardLayoutType.","shared_mutex");
-    if (!is_standard_layout<shared_timed_mutex>::value)
-      LOG("WARNING: Class std::%s does not satisfy concept StandardLayoutType.","shared_timed_mutex");
+    TEST_SL_MV_CPY(mutex)
+    TEST_SL_MV_CPY(recursive_mutex)
+    TEST_SL_MV_CPY(timed_mutex)
+    TEST_SL_MV_CPY(recursive_timed_mutex)
+    TEST_SL_MV_CPY(shared_mutex)
+    TEST_SL_MV_CPY(shared_timed_mutex)
+    TEST_SL_MV_CPY(condition_variable)
+    TEST_SL_MV_CPY(condition_variable_any)
+    static_assert(!std::is_move_constructible<once_flag>::value,
+                  "once_flag must not be move-constructible.");
+    static_assert(!std::is_move_assignable<once_flag>::value,
+                  "once_flag must not be move-assignable.");
+    static_assert(!std::is_copy_constructible<once_flag>::value,
+                  "once_flag must not be copy-constructible.");
+    static_assert(!std::is_copy_assignable<once_flag>::value,
+                  "once_flag must not be copy-assignable.");
+
 //    With C++ feature level and target Windows version potentially affecting
 //  behavior, make this information visible.
     {


### PR DESCRIPTION
To be able to build without exceptions enabled. Required for Clang + Mingw with "-fno-exceptions" flag.