### PR TITLE
Minimize Windows headers

### DIFF
--- a/mingw.condition_variable.h
+++ b/mingw.condition_variable.h
@@ -30,11 +30,15 @@
 #include <cassert>
 #include <chrono>
 #include <system_error>
-#include <windows.h>
 
+#include <sdkddkver.h>  //  Detect Windows version.
 #if (WINVER < _WIN32_WINNT_VISTA)
 #include <atomic>
+#include <windef.h>
+#include <winbase.h>  //  For CreateSemaphore
+#include <handleapi.h>
 #endif
+#include <synchapi.h>
 
 #include "mingw.mutex.h"
 #include "mingw.shared_mutex.h"
@@ -71,7 +75,7 @@ public:
     condition_variable_any(const condition_variable_any&) = delete;
     condition_variable_any& operator=(const condition_variable_any&) = delete;
     condition_variable_any()
-        :   mSemaphore(CreateSemaphore(NULL, 0, 0xFFFF, NULL))
+        :   mSemaphore(CreateSemaphoreA(NULL, 0, 0xFFFF, NULL))
     {
         if (mSemaphore == NULL)
             throw std::system_error(GetLastError(), std::generic_category());
@@ -259,6 +263,7 @@ namespace vista
 //  If compiling for Vista or higher, use the native condition variable.
 class condition_variable
 {
+    static constexpr DWORD kInfinite = 0xffffffffl;
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
     CONDITION_VARIABLE cvariable_ = CONDITION_VARIABLE_INIT;
@@ -345,7 +350,7 @@ public:
 
     void wait (unique_lock<mutex> & lock)
     {
-        wait_impl(lock, INFINITE);
+        wait_impl(lock, kInfinite);
     }
 
     template<class Predicate>
@@ -361,8 +366,8 @@ public:
     {
         using namespace std::chrono;
         auto timeout = duration_cast<milliseconds>(rel_time).count();
-        DWORD waittime = (timeout < INFINITE) ? ((timeout < 0) ? 0 : static_cast<DWORD>(timeout)) : (INFINITE - 1);
-        bool result = wait_impl(lock, waittime) || (timeout >= INFINITE);
+        DWORD waittime = (timeout < kInfinite) ? ((timeout < 0) ? 0 : static_cast<DWORD>(timeout)) : (kInfinite - 1);
+        bool result = wait_impl(lock, waittime) || (timeout >= kInfinite);
         return result ? cv_status::no_timeout : cv_status::timeout;
     }
 
@@ -399,6 +404,7 @@ public:
 
 class condition_variable_any
 {
+    static constexpr DWORD kInfinite = 0xffffffffl;
     using native_shared_mutex = windows7::shared_mutex;
 
     condition_variable internal_cv_ {};
@@ -465,7 +471,7 @@ public:
     template<class L>
     void wait (L & lock)
     {
-        wait_impl(lock, INFINITE);
+        wait_impl(lock, kInfinite);
     }
 
     template<class L, class Predicate>
@@ -480,8 +486,8 @@ public:
     {
         using namespace std::chrono;
         auto timeout = duration_cast<milliseconds>(period).count();
-        DWORD waittime = (timeout < INFINITE) ? ((timeout < 0) ? 0 : static_cast<DWORD>(timeout)) : (INFINITE - 1);
-        bool result = wait_impl(lock, waittime) || (timeout >= INFINITE);
+        DWORD waittime = (timeout < kInfinite) ? ((timeout < 0) ? 0 : static_cast<DWORD>(timeout)) : (kInfinite - 1);
+        bool result = wait_impl(lock, waittime) || (timeout >= kInfinite);
         return result ? cv_status::no_timeout : cv_status::timeout;
     }
 

--- a/mingw.future.h
+++ b/mingw.future.h
@@ -477,11 +477,7 @@ class promise : mingw_stdthread::detail::FutureBase
   {
     if (valid() && !(mState->mType.load(std::memory_order_relaxed) & kSetFlag))
     {
-      try {
-        throw future_error(future_errc::broken_promise);
-      } catch (...) {
-        set_exception(std::current_exception());
-      }
+      set_exception(std::make_exception_ptr(future_error(future_errc::broken_promise)));
     }
   }
 /// \bug Might throw more exceptions than specified by the standard...

--- a/mingw.invoke.h
+++ b/mingw.invoke.h
@@ -1,0 +1,109 @@
+/// \file mingw.invoke.h
+/// \brief Lightweight `invoke` implementation, for C++11 and C++14.
+///
+/// (c) 2018-2019 by Nathaniel J. McClatchey, San Jose, CA, United States
+/// \author Nathaniel J. McClatchey, PhD
+///
+/// \copyright Simplified (2-clause) BSD License.
+///
+/// \note This file may become part of the mingw-w64 runtime package. If/when
+/// this happens, the appropriate license will be added, i.e. this code will
+/// become dual-licensed, and the current BSD 2-clause license will stay.
+
+#ifndef MINGW_INVOKE_H_
+#define MINGW_INVOKE_H_
+
+#include <type_traits>  //  For std::result_of, etc.
+#include <utility>      //  For std::forward
+#include <functional>   //  For std::reference_wrapper
+
+namespace mingw_stdthread
+{
+namespace detail
+{
+//  For compatibility, implement std::invoke for C++11 and C++14
+#if __cplusplus < 201703L
+  template<bool PMemFunc, bool PMemData>
+  struct Invoker
+  {
+    template<class F, class... Args>
+    inline static typename std::result_of<F(Args...)>::type invoke (F&& f, Args&&... args)
+    {
+      return std::forward<F>(f)(std::forward<Args>(args)...);
+    }
+  };
+  template<bool>
+  struct InvokerHelper;
+
+  template<>
+  struct InvokerHelper<false>
+  {
+    template<class T1>
+    inline static auto get (T1&& t1) -> decltype(*std::forward<T1>(t1))
+    {
+      return *std::forward<T1>(t1);
+    }
+
+    template<class T1>
+    inline static auto get (const std::reference_wrapper<T1>& t1) -> decltype(t1.get())
+    {
+      return t1.get();
+    }
+  };
+
+  template<>
+  struct InvokerHelper<true>
+  {
+    template<class T1>
+    inline static auto get (T1&& t1) -> decltype(std::forward<T1>(t1))
+    {
+      return std::forward<T1>(t1);
+    }
+  };
+
+  template<>
+  struct Invoker<true, false>
+  {
+    template<class T, class F, class T1, class... Args>
+    inline static auto invoke (F T::* f, T1&& t1, Args&&... args) ->\
+      decltype((InvokerHelper<std::is_base_of<T,typename std::decay<T1>::type>::value>::get(std::forward<T1>(t1)).*f)(std::forward<Args>(args)...))
+    {
+      return (InvokerHelper<std::is_base_of<T,typename std::decay<T1>::type>::value>::get(std::forward<T1>(t1)).*f)(std::forward<Args>(args)...);
+    }
+  };
+
+  template<>
+  struct Invoker<false, true>
+  {
+    template<class T, class F, class T1, class... Args>
+    inline static auto invoke (F T::* f, T1&& t1, Args&&... args) ->\
+      decltype(InvokerHelper<std::is_base_of<T,typename std::decay<T1>::type>::value>::get(t1).*f)
+    {
+      return InvokerHelper<std::is_base_of<T,typename std::decay<T1>::type>::value>::get(t1).*f;
+    }
+  };
+
+  template<class F, class... Args>
+  struct InvokeResult
+  {
+    typedef Invoker<std::is_member_function_pointer<typename std::remove_reference<F>::type>::value,
+                    std::is_member_object_pointer<typename std::remove_reference<F>::type>::value &&
+                    (sizeof...(Args) == 1)> invoker;
+    inline static auto invoke (F&& f, Args&&... args) -> decltype(invoker::invoke(std::forward<F>(f), std::forward<Args>(args)...))
+    {
+      return invoker::invoke(std::forward<F>(f), std::forward<Args>(args)...);
+    };
+  };
+
+  template<class F, class...Args>
+  auto invoke (F&& f, Args&&... args) -> decltype(InvokeResult<F, Args...>::invoke(std::forward<F>(f), std::forward<Args>(args)...))
+  {
+    return InvokeResult<F, Args...>::invoke(std::forward<F>(f), std::forward<Args>(args)...);
+  }
+#else
+    using std::invoke;
+#endif
+} //  Namespace "detail"
+} //  Namespace "mingw_stdthread"
+
+#endif

--- a/mingw.mutex.h
+++ b/mingw.mutex.h
@@ -50,9 +50,10 @@
 #endif
 #include <synchapi.h> //  For InitializeCriticalSection, etc.
 #include <errhandlingapi.h> //  For GetLastError
+#include <handleapi.h>
 
 //  Need for the implementation of invoke
-#include "mingw.thread.h"
+#include "mingw.invoke.h"
 
 #if !defined(_WIN32_WINNT) || (_WIN32_WINNT < 0x0501)
 #error To use the MinGW-std-threads library, you will need to define the macro _WIN32_WINNT to be 0x0501 (Windows XP) or higher.

--- a/mingw.shared_mutex.h
+++ b/mingw.shared_mutex.h
@@ -98,8 +98,6 @@ public:
             if (expected >= kWriteBit - 1)
             {
                 using namespace std;
-                using namespace this_thread;
-                //yield();
                 expected = mCounter.load(std::memory_order_relaxed);
                 continue;
             }

--- a/mingw.shared_mutex.h
+++ b/mingw.shared_mutex.h
@@ -51,11 +51,12 @@
 //  For defer_lock_t, adopt_lock_t, and try_to_lock_t
 #include "mingw.mutex.h"
 //  For this_thread::yield.
-#include "mingw.thread.h"
+//#include "mingw.thread.h"
 
 //  Might be able to use native Slim Reader-Writer (SRW) locks.
 #ifdef _WIN32
-#include <windows.h>
+#include <sdkddkver.h>  //  Detect Windows version.
+#include <synchapi.h>
 #endif
 
 namespace mingw_stdthread
@@ -98,7 +99,7 @@ public:
             {
                 using namespace std;
                 using namespace this_thread;
-                yield();
+                //yield();
                 expected = mCounter.load(std::memory_order_relaxed);
                 continue;
             }
@@ -144,12 +145,12 @@ public:
 //  Might be able to use relaxed memory order...
 //  Wait for the write-lock to be unlocked, then claim the write slot.
         counter_type current;
-        while ((current = mCounter.fetch_or(kWriteBit, std::memory_order_acquire)) & kWriteBit)
-            this_thread::yield();
+        while ((current = mCounter.fetch_or(kWriteBit, std::memory_order_acquire)) & kWriteBit);
+            //this_thread::yield();
 //  Wait for readers to finish up.
         while (current != kWriteBit)
         {
-            this_thread::yield();
+            //this_thread::yield();
             current = mCounter.load(std::memory_order_acquire);
         }
 #if STDMUTEX_RECURSION_CHECKS

--- a/mingw.thread.h
+++ b/mingw.thread.h
@@ -38,10 +38,7 @@
 #include <iosfwd>       //  Stream output for thread ids.
 #include <utility>      //  For std::swap, std::forward
 
-//  For the invoke implementation only:
-#include <type_traits>  //  For std::result_of, etc.
-//#include <utility>      //  For std::forward
-//#include <functional>   //  For std::reference_wrapper
+#include "mingw.invoke.h"
 
 #include <synchapi.h>   //  For WaitForSingleObject
 #include <handleapi.h>  //  For CloseHandle, etc.
@@ -62,89 +59,6 @@ namespace mingw_stdthread
 {
 namespace detail
 {
-//  For compatibility, implement std::invoke for C++11 and C++14
-#if __cplusplus < 201703L
-  template<bool PMemFunc, bool PMemData>
-  struct Invoker
-  {
-    template<class F, class... Args>
-    inline static typename std::result_of<F(Args...)>::type invoke (F&& f, Args&&... args)
-    {
-      return std::forward<F>(f)(std::forward<Args>(args)...);
-    }
-  };
-  template<bool>
-  struct InvokerHelper;
-
-  template<>
-  struct InvokerHelper<false>
-  {
-    template<class T1>
-    inline static auto get (T1&& t1) -> decltype(*std::forward<T1>(t1))
-    {
-      return *std::forward<T1>(t1);
-    }
-
-    template<class T1>
-    inline static auto get (const std::reference_wrapper<T1>& t1) -> decltype(t1.get())
-    {
-      return t1.get();
-    }
-  };
-
-  template<>
-  struct InvokerHelper<true>
-  {
-    template<class T1>
-    inline static auto get (T1&& t1) -> decltype(std::forward<T1>(t1))
-    {
-      return std::forward<T1>(t1);
-    }
-  };
-
-  template<>
-  struct Invoker<true, false>
-  {
-    template<class T, class F, class T1, class... Args>
-    inline static auto invoke (F T::* f, T1&& t1, Args&&... args) ->\
-      decltype((InvokerHelper<std::is_base_of<T,typename std::decay<T1>::type>::value>::get(std::forward<T1>(t1)).*f)(std::forward<Args>(args)...))
-    {
-      return (InvokerHelper<std::is_base_of<T,typename std::decay<T1>::type>::value>::get(std::forward<T1>(t1)).*f)(std::forward<Args>(args)...);
-    }
-  };
-
-  template<>
-  struct Invoker<false, true>
-  {
-    template<class T, class F, class T1, class... Args>
-    inline static auto invoke (F T::* f, T1&& t1, Args&&... args) ->\
-      decltype(InvokerHelper<std::is_base_of<T,typename std::decay<T1>::type>::value>::get(t1).*f)
-    {
-      return InvokerHelper<std::is_base_of<T,typename std::decay<T1>::type>::value>::get(t1).*f;
-    }
-  };
-
-  template<class F, class... Args>
-  struct InvokeResult
-  {
-    typedef Invoker<std::is_member_function_pointer<typename std::remove_reference<F>::type>::value,
-                    std::is_member_object_pointer<typename std::remove_reference<F>::type>::value &&
-                    (sizeof...(Args) == 1)> invoker;
-    inline static auto invoke (F&& f, Args&&... args) -> decltype(invoker::invoke(std::forward<F>(f), std::forward<Args>(args)...))
-    {
-      return invoker::invoke(std::forward<F>(f), std::forward<Args>(args)...);
-    };
-  };
-
-  template<class F, class...Args>
-  auto invoke (F&& f, Args&&... args) -> decltype(InvokeResult<F, Args...>::invoke(std::forward<F>(f), std::forward<Args>(args)...))
-  {
-    return InvokeResult<F, Args...>::invoke(std::forward<F>(f), std::forward<Args>(args)...);
-  }
-#else
-    using std::invoke;
-#endif
-
     template<std::size_t...>
     struct IntSeq {};
 


### PR DESCRIPTION
To reduce macro pollution, as in #54, replaces `windows.h` with some of its component headers. Likewise, break a dependency on `mingw.thread.h` by separating the `invoke` implementation (used by 3 headers) into its own file.