### PR TITLE
Fix fatal bug: Threads must copy arguments.

### DIFF
--- a/mingw.thread.h
+++ b/mingw.thread.h
@@ -72,18 +72,22 @@ namespace detail
     template<class Func, typename... Args>
     class ThreadFuncCall
     {
-        typedef std::tuple<Args...> Tuple;
-        Func mFunc;
+        using Tuple = std::tuple<typename std::decay<Args>::type...>;
+        typename std::decay<Func>::type mFunc;
         Tuple mArgs;
 
         template <std::size_t... S>
         void callFunc(detail::IntSeq<S...>)
         {
-            detail::invoke(std::forward<Func>(mFunc), std::get<S>(std::forward<Tuple>(mArgs)) ...);
+//  Note: Only called once (per thread)
+            detail::invoke(std::move(mFunc), std::move(std::get<S>(mArgs)) ...);
         }
     public:
         ThreadFuncCall(Func&& aFunc, Args&&... aArgs)
-        :mFunc(std::forward<Func>(aFunc)), mArgs(std::forward<Args>(aArgs)...){}
+          : mFunc(std::forward<Func>(aFunc)),
+            mArgs(std::forward<Args>(aArgs)...)
+        {
+        }
 
         void callFunc()
         {


### PR DESCRIPTION
In #58 , @phma noticed an issue, in that threads which were passed an argument in a for loop were not properly disambiguated by it. I have replicated the behavior, and determined that it is caused by the thread constructor not properly copying its arguments. This is a fatal flaw, so it must be addressed immediately.

This pull request eliminates the problem using the following steps:
- Force use of the standard's prescribed behavior (make a copy of type `std::decay<T>::type` for each argument of the thread's constructor).
- Add regression test to identify (and treat as fatal) this flaw if it is reintroduced.

I recommend immediately updating this library. All projects that use this library should update their copy and recompile.

@alxvasilev , please merge this *ASAP*.