### PR TITLE
Miscellaneous improvements

### DIFF
--- a/mingw.invoke.h
+++ b/mingw.invoke.h
@@ -92,7 +92,7 @@ namespace detail
     inline static auto invoke (F&& f, Args&&... args) -> decltype(invoker::invoke(std::forward<F>(f), std::forward<Args>(args)...))
     {
       return invoker::invoke(std::forward<F>(f), std::forward<Args>(args)...);
-    };
+    }
   };
 
   template<class F, class...Args>

--- a/mingw.thread.h
+++ b/mingw.thread.h
@@ -177,9 +177,9 @@ public:
         using Call = detail::ThreadFuncCall<Func, ArgSequence, Args...>;
         auto call = new Call(
             std::forward<Func>(func), std::forward<Args>(args)...);
+        unsigned id_receiver;
         auto int_handle = _beginthreadex(NULL, 0, threadfunc<Call>,
-            static_cast<LPVOID>(call), 0,
-            reinterpret_cast<unsigned*>(&(mThreadId.mId)));
+            static_cast<LPVOID>(call), 0, &id_receiver);
         if (int_handle == 0)
         {
             mHandle = kInvalidHandle;
@@ -187,8 +187,10 @@ public:
             delete call;
 //  Note: Should only throw EINVAL, EAGAIN, EACCES
             throw std::system_error(errnum, std::generic_category());
-        } else
+        } else {
+            mThreadId.mId = id_receiver;
             mHandle = reinterpret_cast<HANDLE>(int_handle);
+        }
     }
 
     bool joinable() const {return mHandle != kInvalidHandle;}

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -263,6 +263,8 @@ void test_future ()
 
 int main()
 {
+    static_assert(std::is_trivially_copyable<thread::id>::value,
+                  "thread::id must be trivially copyable.");
     TEST_SL_MV_CPY(mutex)
     TEST_SL_MV_CPY(recursive_mutex)
     TEST_SL_MV_CPY(timed_mutex)


### PR DESCRIPTION
Standard-compliance improvements:
- Removes public non-default constructor from `thread::id`.
- Adds regression test for `thread::id`'s TriviallyCopyable property.

Robustness improvements:
- Replace an instance of undefined behavior (`DWORD *` reinterpreted as `unsigned *`) with standard-compliant behavior (pass pointer to existing unsigned, statically cast the result to DWORD).

(Possible) performance improvements:
- Remove possibility of compiler failing to inline a wrapper function by calling directly.