### PR TITLE
Detect when MinGW-w32 is used

### DIFF
--- a/mingw.condition_variable.h
+++ b/mingw.condition_variable.h
@@ -34,11 +34,20 @@
 #include <sdkddkver.h>  //  Detect Windows version.
 #if (WINVER < _WIN32_WINNT_VISTA)
 #include <atomic>
+#endif
+#if (defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR))
+#pragma message "The Windows API that MinGW-w32 provides is not fully compatible\
+ with Microsoft's API. We'll try to work around this, but we can make no\
+ guarantees. This problem does not exist in MinGW-w64."
+#include <windows.h>    //  No further granularity can be expected.
+#else
+#if (WINVER < _WIN32_WINNT_VISTA)
 #include <windef.h>
 #include <winbase.h>  //  For CreateSemaphore
 #include <handleapi.h>
 #endif
 #include <synchapi.h>
+#endif
 
 #include "mingw.mutex.h"
 #include "mingw.shared_mutex.h"

--- a/mingw.future.h
+++ b/mingw.future.h
@@ -34,9 +34,16 @@
 #include "mingw.mutex.h"
 #include "mingw.condition_variable.h"
 
+#if (defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR))
+#pragma message "The Windows API that MinGW-w32 provides is not fully compatible\
+ with Microsoft's API. We'll try to work around this, but we can make no\
+ guarantees. This problem does not exist in MinGW-w64."
+#include <windows.h>    //  No further granularity can be expected.
+#else
 #include <synchapi.h>
 #include <handleapi.h>
 #include <processthreadsapi.h>
+#endif
 
 //  Note:
 //    std::shared_ptr is the natural choice for this. However, a custom

--- a/mingw.mutex.h
+++ b/mingw.mutex.h
@@ -43,14 +43,21 @@
 #include <cstdio>
 #endif
 
-
 #include <sdkddkver.h>  //  Detect Windows version.
+
+#if (defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR))
+#pragma message "The Windows API that MinGW-w32 provides is not fully compatible\
+ with Microsoft's API. We'll try to work around this, but we can make no\
+ guarantees. This problem does not exist in MinGW-w64."
+#include <windows.h>    //  No further granularity can be expected.
+#else
 #if STDMUTEX_RECURSION_CHECKS
 #include <processthreadsapi.h>  //  For GetCurrentThreadId
 #endif
 #include <synchapi.h> //  For InitializeCriticalSection, etc.
 #include <errhandlingapi.h> //  For GetLastError
 #include <handleapi.h>
+#endif
 
 //  Need for the implementation of invoke
 #include "mingw.invoke.h"

--- a/mingw.shared_mutex.h
+++ b/mingw.shared_mutex.h
@@ -56,7 +56,14 @@
 //  Might be able to use native Slim Reader-Writer (SRW) locks.
 #ifdef _WIN32
 #include <sdkddkver.h>  //  Detect Windows version.
+#if (defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR))
+#pragma message "The Windows API that MinGW-w32 provides is not fully compatible\
+ with Microsoft's API. We'll try to work around this, but we can make no\
+ guarantees. This problem does not exist in MinGW-w64."
+#include <windows.h>    //  No further granularity can be expected.
+#else
 #include <synchapi.h>
+#endif
 #endif
 
 namespace mingw_stdthread

--- a/mingw.thread.h
+++ b/mingw.thread.h
@@ -40,10 +40,17 @@
 
 #include "mingw.invoke.h"
 
+#if (defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR))
+#pragma message "The Windows API that MinGW-w32 provides is not fully compatible\
+ with Microsoft's API. We'll try to work around this, but we can make no\
+ guarantees. This problem does not exist in MinGW-w64."
+#include <windows.h>    //  No further granularity can be expected.
+#else
 #include <synchapi.h>   //  For WaitForSingleObject
 #include <handleapi.h>  //  For CloseHandle, etc.
 #include <sysinfoapi.h> //  For GetNativeSystemInfo
 #include <processthreadsapi.h>  //  For GetCurrentThreadId
+#endif
 #include <process.h>  //  For _beginthreadex
 
 #ifndef NDEBUG


### PR DESCRIPTION
MinGW-w32's version of the Windows API is lacking certain headers. In particular, it includes `windows.h`, but not the more granular headers such as `synchapi.h`. Though the library's users would be best served by upgrading to MinGW-w64, supporting the legacy MinGW-w32 should increase the versatility of the library with minimal effort.