### PR TITLE
Fix: conflicts with a previous declaration in GCC 11

### DIFF
--- a/mingw.mutex.h
+++ b/mingw.mutex.h
@@ -431,6 +431,7 @@ public:
 typedef recursive_timed_mutex timed_mutex;
 #endif
 
+#if defined(__GNUC__) && __GNUC__ < 11
 class once_flag
 {
 //    When available, the SRW-based mutexes should be faster than the
@@ -461,6 +462,7 @@ void call_once(once_flag& flag, Callable&& func, Args&&... args)
     detail::invoke(std::forward<Callable>(func),std::forward<Args>(args)...);
     flag.mHasRun.store(true, std::memory_order_release);
 }
+#endif
 } //  Namespace mingw_stdthread
 
 //  Push objects into std, but only if they are not already there.
@@ -471,13 +473,15 @@ namespace std
 //  was none. Direct specification (std::), however, would be unaffected.
 //    Take the safe option, and include only in the presence of MinGW's win32
 //  implementation.
-#if defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS)
+#if defined(__GNUC__) && defined(__MINGW32__) && !defined(_GLIBCXX_HAS_GTHREADS)
 using mingw_stdthread::recursive_mutex;
 using mingw_stdthread::mutex;
 using mingw_stdthread::recursive_timed_mutex;
 using mingw_stdthread::timed_mutex;
+#if __GNUC__ < 11
 using mingw_stdthread::once_flag;
 using mingw_stdthread::call_once;
+#endif
 #elif !defined(MINGW_STDTHREAD_REDUNDANCY_WARNING)  //  Skip repetition
 #define MINGW_STDTHREAD_REDUNDANCY_WARNING
 #pragma message "This version of MinGW seems to include a win32 port of\

--- a/mingw.thread.h
+++ b/mingw.thread.h
@@ -105,6 +105,7 @@ namespace detail
     class ThreadIdTool;
 } //  Namespace "detail"
 
+#if defined(__GNUC__) && __GNUC__ < 11
 class thread
 {
 public:
@@ -317,6 +318,7 @@ namespace this_thread
         sleep_for(sleep_time-Clock::now());
     }
 }
+#endif
 } //  Namespace mingw_stdthread
 
 namespace std
@@ -326,7 +328,8 @@ namespace std
 //  was none. Direct specification (std::), however, would be unaffected.
 //    Take the safe option, and include only in the presence of MinGW's win32
 //  implementation.
-#if defined(__MINGW32__ ) && !defined(_GLIBCXX_HAS_GTHREADS)
+#if defined(__GNUC__) && defined(__MINGW32__) && !defined(_GLIBCXX_HAS_GTHREADS)
+#if __GNUC__ < 11
 using mingw_stdthread::thread;
 //    Remove ambiguity immediately, to avoid problems arising from the above.
 //using std::thread;
@@ -334,6 +337,7 @@ namespace this_thread
 {
 using namespace mingw_stdthread::this_thread;
 }
+#endif
 #elif !defined(MINGW_STDTHREAD_REDUNDANCY_WARNING)  //  Skip repetition
 #define MINGW_STDTHREAD_REDUNDANCY_WARNING
 #pragma message "This version of MinGW seems to include a win32 port of\
@@ -344,6 +348,7 @@ using namespace mingw_stdthread::this_thread;
  namespace mingw_stdthread."
 #endif
 
+#if defined(__GNUC__) && __GNUC__ < 11
 //    Specialize hash for this implementation's thread::id, even if the
 //  std::thread::id already has a hash.
 template<>
@@ -356,5 +361,6 @@ struct hash<mingw_stdthread::thread::id>
         return i.mId;
     }
 };
+#endif
 }
 #endif // WIN32STDTHREAD_H


### PR DESCRIPTION
https://github.com/gcc-mirror/gcc/commit/93e79ed391b9c636f087e6eb7e70f14963cd10ad#diff-5a6ec96bdb4bb5cbf2f6b26682e74429c1900ca5852e9b1a87a65eb70d79f41a
```
../mingw.mutex.h:479:24: error: 'class mingw_stdthread::once_flag' conflicts with a previous declaration
  479 | using mingw_stdthread::once_flag;
      |                        ^~~~~~~~~
In file included from ../mingw.mutex.h:40,
                 from ../mingw.condition_variable.h:52,
                 from threadpool.h:36,
                 from threadpool.cc:15:
c:\msys1100\include\c++\11.0.0\mutex:673:10: note: previous declaration 'struct std::once_flag'
  673 |   struct once_flag
      |          ^~~~~~~~~
```