### PR TITLE
Fix timed mutex, tweak call_once

### DIFF
--- a/mingw.mutex.h
+++ b/mingw.mutex.h
@@ -403,6 +403,7 @@ public:
 class timed_mutex: recursive_timed_mutex
 {
 public:
+    timed_mutex() = default;
     timed_mutex(const timed_mutex&) = delete;
     timed_mutex& operator=(const timed_mutex&) = delete;
     void lock()

--- a/mingw.mutex.h
+++ b/mingw.mutex.h
@@ -465,7 +465,7 @@ void call_once(once_flag& flag, Callable&& func, Args&&... args)
     if (flag.mHasRun.load(std::memory_order_acquire))
         return;
     lock_guard<decltype(flag.mMutex)> lock(flag.mMutex);
-    if (flag.mHasRun.load(std::memory_order_acquire))
+    if (flag.mHasRun.load(std::memory_order_relaxed))
         return;
     detail::invoke(std::forward<Callable>(func),std::forward<Args>(args)...);
     flag.mHasRun.store(true, std::memory_order_release);


### PR DESCRIPTION
Fixes the `timed_mutex` class to have a constructor (was failing due to the base class being inherited privately). This fixes #84 .

Adjusts the second read in `call_once` to use relaxed semantics, rather than acquire semantics. This should slightly improve performance, and is correct because this second load occurs after acquiring the mutex, which in itself acquires the result of the called function.