### PR TITLE
Add latch header implementation

### DIFF
--- a/cmake_stdheaders_generator/CMakeLists.txt
+++ b/cmake_stdheaders_generator/CMakeLists.txt
@@ -61,6 +61,8 @@ endif()
 generate_mingw_stdthreads_header(condition_variable "${MINGW_STDTHREADS_DIR}")
 # <future>
 generate_mingw_stdthreads_header(future "${MINGW_STDTHREADS_DIR}")
+# <latch>
+generate_mingw_stdthreads_header(latch "${MINGW_STDTHREADS_DIR}")
 # <mutex>
 generate_mingw_stdthreads_header(mutex "${MINGW_STDTHREADS_DIR}")
 # <shared_mutex>

--- a/mingw.latch.h
+++ b/mingw.latch.h
@@ -72,14 +72,14 @@ public:
 
     /**
     * The call to atomic::wait() may unblock with a non-zero counter in some edge cases (see GH-91 for an in-depth explanation)
-    * To address the edge cases this loop will continue to wait until the counter has been verified to have reached a non-positive value
+    * To address the edge cases this loop will continue to wait until the counter has been verified to have reached 0 (or less)
     */         
     void wait() const
     {
         while (true)
         {
             const auto current = mCounter.load(std::memory_order_acquire);
-            if (current < 0)
+            if (current <= 0)
             {
                 return;
             }

--- a/mingw.latch.h
+++ b/mingw.latch.h
@@ -1,0 +1,113 @@
+/// \file mingw.latch.h
+/// \brief std::latch implementation for MinGW.
+///
+/// (c) 2023 by Mega Limited, Auckland, New Zealand
+/// \author Edoardo Sanguineti
+///
+/// \copyright Simplified (2-clause) BSD License.
+///
+/// \note This file may become part of the mingw-w64 runtime package. If/when
+/// this happens, the appropriate license will be added, i.e. this code will
+/// become dual-licensed, and the current BSD 2-clause license will stay.
+
+//  Notes on the namespaces:
+//  - The implementation can be accessed directly in the namespace
+//    mingw_stdthread.
+//  - Objects will be brought into namespace std by a using directive. This
+//    will cause objects declared in std (such as MinGW's implementation) to
+//    hide this implementation's definitions.
+//  The end result is that if MinGW supplies an object, it is automatically
+//  used. If MinGW does not supply an object, this implementation's version will
+//  instead be used.
+
+#ifndef MINGW_LATCH_H_
+#define MINGW_LATCH_H_
+
+#if !defined(__cplusplus) || (__cplusplus < 202002L)
+#error The contents of <latch> require a C++20 compiler!
+#endif
+
+#include <sdkddkver.h>    //  Detect Windows version
+#if !defined(_WIN32_WINNT) || (_WIN32_WINNT < 0x0501)
+#error To use the MinGW-std-threads library, you will need to define the macro _WIN32_WINNT to be 0x0501 (Windows XP) or higher.
+#endif
+
+#include <atomic>
+#include <cassert>        // for descriptive errors
+#include <cstddef>        // for std::ptrdiff_t
+#include <limits>         // for std::numeric_limits
+
+namespace mingw_stdthread
+{
+class latch
+{
+public:
+    [[nodiscard]] static constexpr std::ptrdiff_t max() noexcept
+    {
+        return std::numeric_limits<std::ptrdiff_t>::max();
+    }
+
+    constexpr explicit latch(std::ptrdiff_t expected) : mCounter{expected}
+    {
+    }
+
+    ~latch()=default;
+    latch(const latch&)=delete;
+    latch& operator=(const latch&)=delete;
+
+    void count_down(std::ptrdiff_t update = 1 )
+    {
+        assert(update >= 0);
+
+        const auto current = mCounter.fetch_sub(update, std::memory_order_release) - update;
+        if (current == 0)
+        {
+            mCounter.notify_all();
+        }
+    }
+
+    [[nodiscard]] bool try_wait() const noexcept
+    {
+        return 0 == mCounter.load(std::memory_order_acquire);
+    }
+
+    void wait() const
+    {
+        const auto current = mCounter.load(std::memory_order_acquire);
+        if (current == 0)
+        {
+            return;
+        }
+
+        mCounter.wait(current, std::memory_order_relaxed);
+    }
+
+    void arrive_and_wait(const std::ptrdiff_t update = 1) noexcept
+    {
+        assert(update >= 0);
+
+        const auto current = mCounter.fetch_sub(update, std::memory_order_acq_rel) - update;
+        if (current == 0)
+        {
+            mCounter.notify_all();
+        }
+        else
+        {
+            assert(current > 0);
+
+            mCounter.wait(current, std::memory_order_relaxed);
+            wait();
+        }
+    }
+
+private:
+    std::atomic<std::ptrdiff_t> mCounter;
+};
+} //  Namespace mingw_stdthread
+
+namespace std
+{
+using mingw_stdthread::latch;
+} //  Namespace std
+
+#endif // MINGW_LATCH_H_

--- a/mingw.latch.h
+++ b/mingw.latch.h
@@ -51,7 +51,7 @@ public:
     latch(const latch&)=delete;
     latch& operator=(const latch&)=delete;
 
-    void count_down(std::ptrdiff_t update = 1 )
+    void count_down(std::ptrdiff_t update = 1)
     {
         assert(update >= 0);
 

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -4,14 +4,22 @@
   #include <mingw.condition_variable.h>
   #include <mingw.shared_mutex.h>
   #include <mingw.future.h>
-  #include <mingw.latch.h>
+
+  #if defined(__cplusplus) && (__cplusplus >= 202002L)
+    #include <mingw.latch.h>
+  #endif
+
 #else
   #include <thread>
   #include <mutex>
   #include <condition_variable>
   #include <shared_mutex>
   #include <future>
-  #include <latch>
+
+  #if defined(__cplusplus) && (__cplusplus >= 202002L)
+    #include <latch>
+  #endif
+
 #endif
 #include <atomic>
 #include <cassert>
@@ -36,7 +44,7 @@ std::atomic<unsigned long long> failure_count {0};
 template<class ... Args>
 void log_error (char const * fmtString, Args ...args) {
   ++failure_count;
-   printf("%s", "ERROR: ");
+  printf("%s", "ERROR: ");
   printf(fmtString, args...);
   printf("%s", "\n");
   fflush(stdout);
@@ -295,6 +303,8 @@ void test_future ()
   test_future_get_value(async_member);
 }
 
+#if defined(__cplusplus) && (__cplusplus >= 202002L)
+
 void test_latch ()
 {
   std::latch latch(5);
@@ -323,9 +333,25 @@ void test_latch_release_wait ()
   log("Testing release_wait...");
   latch.arrive_and_wait(2);
 
+  log("Testing try_wait...");
+  if (!latch.try_wait())
+  {
+    log_error("try_wait did not return true even though the internal counter should have reached 0");
+  }
+
   thread1.join();
   thread2.join();
 }
+
+void test_latch_noexcept()
+{
+  static_assert(noexcept(std::latch::max()));
+  static_assert(noexcept(std::latch::latch()));
+  static_assert(noexcept(std::latch::try_wait()));
+  static_assert(noexcept(std::latch::arrive_and_wait()));
+}
+
+#endif // defined(__cplusplus) && (__cplusplus >= 202002L)
 
 #define TEST_SL_MV_CPY(ClassName) \
     static_assert(std::is_standard_layout<ClassName>::value, \
@@ -516,11 +542,14 @@ int main()
       allocated_promise.set_value(7);
     }
 
+#if defined(__cplusplus) && (__cplusplus >= 202002L)
     {
       log("Testing implementation of <latch>...");
       test_latch();
       test_latch_release_wait();
+      test_latch_noexcept();
     }
+#endif
 
     return failure_count.load() != 0;
 }

--- a/utility_scripts/Generate-StdLikeHeaders.ps1
+++ b/utility_scripts/Generate-StdLikeHeaders.ps1
@@ -62,7 +62,7 @@ param (
 $ErrorActionPreference = "Stop";
 
 # headers to be generated
-$headers = @("condition_variable", "future", "mutex", "shared_mutex", "thread")
+$headers = @("condition_variable", "future", "latch", "mutex", "shared_mutex", "thread")
 
 # ask for user input in interactive mode
 if ($Interactive) {


### PR DESCRIPTION
Hello, this is my first contribution to this repository. I saw there are open issues for some C++20 features and since `latch` looked pretty easy I gave it a go. As suggested by the person that created the issue I used `<atomic>` based implementation. This means it may render this feature unusable on Windows versions older than Vista. However, it greatly simplifies the code and it seems it is the choice of other C++ STL implementations.

I tried my best to follow the conventions of this repository but I invite any reviewer to check if I am missing any special header guard, especially at the bottom of the file to check in an implementation is already available.

- [x] #67
- [x] Add basic test coverage
- [x] Add the header to the various tools used to generate `<latch>` (to double-check if everything is included)
- [x] Reviewer needs to double-check for missing special MINGW header guards in the `<latch>` header

Closes #67 