### PR TITLE
Add PowerShell Fixes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+[Oo]utput


### PR DESCRIPTION
- Use default generation destination of `output`.
- Do not error when a MinGW version does not have a header.
- Generate for `invoke` and `latch` correctly.
- Various fixes.